### PR TITLE
ENH improve robustness to scale for optimization

### DIFF
--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -420,7 +420,8 @@ def _online_learn(X, D_hat, z_hat, compute_z_func, compute_d_func,
         # Compute z update
         start = time.time()
         if batch_selection == 'random':
-            i0 = np.random.choice(n_trials, batch_size, replace=False)
+            rng = check_random_state(random_state)
+            i0 = rng.choice(n_trials, batch_size, replace=False)
         elif batch_selection == 'cyclic':
             i_slice = (ii * batch_size) % n_trials
             i0 = slice(i_slice, i_slice + batch_size)

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -151,6 +151,10 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
     n_trials, n_channels, n_times = X.shape
     n_times_valid = n_times - n_times_atom + 1
 
+    # Rescale the problem to avoid underflow issues
+    std_X = X.std()
+    X = X / std_X
+
     # initialization
     start = time.time()
     rng = check_random_state(random_state)
@@ -263,6 +267,10 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
     if verbose > 0:
         print("[%s] Fit in %.1fs" % (name, time.time() - start))
 
+    # Rescale the solution to match the given scale of the problem
+    z_hat *= std_X
+    reg *= std_X
+
     return pobj, times, D_hat, z_hat, reg
 
 
@@ -271,7 +279,6 @@ def _batch_learn(X, D_hat, z_hat, compute_z_func, compute_d_func,
                  lmbd_max='fixed', reg=None, verbose=0, greedy=False,
                  random_state=None, name="batch", uv_constraint='separate',
                  window=False):
-
     reg_ = reg
 
     # Initialize constants dictionary

--- a/alphacsc/online_dictionary_learning.py
+++ b/alphacsc/online_dictionary_learning.py
@@ -57,7 +57,7 @@ class OnlineCDL(ConvolutionalDictionaryLearning):
             name="OnlineCDL")
 
     def partial_fit(self, X, y=None):
-        # Successice partial_fit are equivalent to OnlineCDL only if
+        # Successive partial_fit are equivalent to OnlineCDL only if
         # the X passed to this method are taken from a normalized
         # X_full ( X_full / X_full.std())
         self._check_param_partial_fit()

--- a/alphacsc/online_dictionary_learning.py
+++ b/alphacsc/online_dictionary_learning.py
@@ -57,6 +57,9 @@ class OnlineCDL(ConvolutionalDictionaryLearning):
             name="OnlineCDL")
 
     def partial_fit(self, X, y=None):
+        # Successice partial_fit are equivalent to OnlineCDL only if
+        # the X passed to this method are taken from a normalized
+        # X_full ( X_full / X_full.std())
         self._check_param_partial_fit()
         self._ensure_fit_init(X)
 

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -20,8 +20,8 @@ from alphacsc.init_dict import init_dictionary
     ])
 def test_learn_d_z_multi(loss, solver_d, uv_constraint, rank1, window):
     # smoke test for learn_d_z_multi
-    n_trials, n_channels, n_times = 2, 3, 100
-    n_times_atom, n_atoms = 10, 4
+    n_trials, n_channels, n_times = 2, 3, 30
+    n_times_atom, n_atoms = 6, 4
 
     loss_params = dict(gamma=1, sakoe_chiba_band=10, ordar=10)
 

--- a/alphacsc/tests/test_loss_and_gradient.py
+++ b/alphacsc/tests/test_loss_and_gradient.py
@@ -75,8 +75,8 @@ def gradient_checker(func, grad, shape, args=(), kwargs={}, n_checks=10,
 def test_consistency(loss, func):
     """Check that the result are the same for the full rank D and rank 1 uv.
     """
-    n_trials, n_channels, n_times = 5, 3, 100
-    n_atoms, n_times_atom = 10, 15
+    n_trials, n_channels, n_times = 5, 3, 30
+    n_atoms, n_times_atom = 4, 7
 
     loss_params = dict(gamma=.01)
 

--- a/alphacsc/tests/test_online_dictionary_learning.py
+++ b/alphacsc/tests/test_online_dictionary_learning.py
@@ -10,11 +10,12 @@ from alphacsc.online_dictionary_learning import OnlineCDL
 def test_online_partial_fit(rank1, alpha):
     # Ensure that partial fit reproduce the behavior of the online algorithm if
     # feed with the same batch size and order.
-    n_trials, n_channels, n_times = 10, 3, 100
+    n_trials, n_channels, n_times = 10, 3, 30
     n_times_atom, n_atoms = 6, 4
 
     rng = check_random_state(42)
     X = rng.randn(n_trials, n_channels, n_times)
+    X /= X.std()
 
     # The initial regularization is different for fit and partial_fit. It is
     # computed in batch mode for fit and with the first mini-batch in

--- a/alphacsc/tests/test_online_dictionary_learning.py
+++ b/alphacsc/tests/test_online_dictionary_learning.py
@@ -15,6 +15,8 @@ def test_online_partial_fit(rank1, alpha):
 
     rng = check_random_state(42)
     X = rng.randn(n_trials, n_channels, n_times)
+    # Need to have a unit norm signal to have the equivalence between
+    # successive partial_fit and OnlineCDL
     X /= X.std()
 
     # The initial regularization is different for fit and partial_fit. It is

--- a/alphacsc/update_z_multi.py
+++ b/alphacsc/update_z_multi.py
@@ -6,12 +6,13 @@
 import time
 
 import numpy as np
-from scipy import optimize, sparse
+from scipy import optimize
 from joblib import Parallel, delayed
 
 
 from . import cython_code
 from .utils.optim import fista
+from .utils import check_random_state
 from .loss_and_gradient import gradient_zi
 from .utils.lil import is_list_of_lil, is_lil
 from .utils.coordinate_descent import _coordinate_descent_idx
@@ -20,7 +21,8 @@ from .utils.compute_constants import compute_DtD, compute_ztz, compute_ztX
 
 def update_z_multi(X, D, reg, z0=None, solver='l-bfgs', solver_kwargs=dict(),
                    loss='l2', loss_params=dict(), freeze_support=False,
-                   return_ztz=False, timing=False, n_jobs=1, debug=False):
+                   return_ztz=False, timing=False, n_jobs=1,
+                   random_state=None, debug=False):
     """Update z using L-BFGS with positivity constraints
 
     Parameters
@@ -53,8 +55,12 @@ def update_z_multi(X, D, reg, z0=None, solver='l-bfgs', solver_kwargs=dict(),
         time taken by each iteration for each signal.
     n_jobs : int
         The number of parallel jobs.
+    random_state : None or int or RandomState
+        random_state to make randomized experiments determinist. If None, no
+        random_state is given. If it is an integer, it will be used to seed a
+        RandomState.
     debug : bool
-        If True, check the grad.
+        If True, check the gradients.
 
     Returns
     -------
@@ -69,6 +75,10 @@ def update_z_multi(X, D, reg, z0=None, solver='l-bfgs', solver_kwargs=dict(),
         n_atoms, n_channels, n_times_atom = D.shape
     n_times_valid = n_times - n_times_atom + 1
 
+    # Generate different seeds for the parallel updates
+    rng = check_random_state(random_state)
+    parallel_seeds = [rng.randint(2**32) for _ in range(n_trials)]
+
     if z0 is None:
         z0 = np.zeros((n_trials, n_atoms, n_times_valid))
 
@@ -78,8 +88,9 @@ def update_z_multi(X, D, reg, z0=None, solver='l-bfgs', solver_kwargs=dict(),
     results = Parallel(n_jobs=n_jobs)(
         delayed_update_z(X[i], D, reg, z0[i], debug, solver, solver_kwargs,
                          freeze_support, loss, loss_params=loss_params,
-                         return_ztz=return_ztz, timing=timing)
-        for i in np.arange(n_trials))
+                         return_ztz=return_ztz,
+                         timing=timing, random_state=seed)
+        for i, seed in enumerate(parallel_seeds))
 
     # Post process the results to get separate objects
     z_hats, pobj, times = [], [], []
@@ -121,7 +132,8 @@ class BoundGenerator(object):
 
 def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
                         solver_kwargs=dict(), freeze_support=False, loss='l2',
-                        loss_params=dict(), return_ztz=False, timing=False):
+                        loss_params=dict(), return_ztz=False,
+                        timing=False, random_state=None):
     t_start = time.time()
     n_channels, n_times = X_i.shape
     if D.ndim == 2:
@@ -136,6 +148,8 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
     if is_lil(z0_i) and solver != "lgcd":
         raise NotImplementedError()
 
+    rng = check_random_state(random_state)
+
     constants = {}
     if solver == "lgcd":
         constants['DtD'] = compute_DtD(D=D, n_channels=n_channels)
@@ -147,21 +161,18 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
                            loss=loss, loss_params=loss_params)
 
     if z0_i is None:
-        f0 = np.zeros(n_atoms * n_times_valid)
-    elif is_lil(z0_i):
-        f0 = z0_i
-    else:
-        f0 = z0_i.reshape(n_atoms * n_times_valid)
+        z0_i = np.zeros(n_atoms, n_times_valid)
 
     times, pobj = None, None
     if timing:
         times = [init_timing]
-        pobj = [func_and_grad(f0)[0]]
+        pobj = [func_and_grad(z0_i)[0]]
         t_start = [time.time()]
 
     if solver == 'l-bfgs':
+        z0_i = z0_i.ravel()
         if freeze_support:
-            bounds = [(0, 0) if z == 0 else (0, None) for z in f0]
+            bounds = [(0, 0) if z == 0 else (0, None) for z in z0_i]
         else:
             bounds = BoundGenerator(n_atoms * n_times_valid)
         if timing:
@@ -175,14 +186,13 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
         factr = solver_kwargs.get('factr', 1e15)  # default value
         maxiter = solver_kwargs.get('maxiter', 15000)  # default value
         z_hat, f, d = optimize.fmin_l_bfgs_b(
-            func_and_grad, f0, fprime=None, args=(), approx_grad=False,
+            func_and_grad, x0=z0_i, fprime=None, args=(), approx_grad=False,
             bounds=bounds, factr=factr, maxiter=maxiter, callback=callback)
 
     elif solver in ("ista", "fista"):
         # Default args
         fista_kwargs = dict(
-            max_iter=100, eps=None, verbose=0, restart=None,
-            scipy_line_search=False,
+            max_iter=100, eps=None, verbose=0, scipy_line_search=False,
             momentum=(solver == "fista")
         )
         fista_kwargs.update(solver_kwargs)
@@ -193,10 +203,10 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
         def grad(z_hat):
             return func_and_grad(z_hat)[1]
 
-        def prox(z_hat,):
-            return np.maximum(z_hat, 0.)
-
-        output = fista(objective, grad, prox, None, f0,
+        def prox(z_hat, step_size=0):
+            return np.maximum(z_hat - step_size * reg, 0.)
+        z0_i = z0_i.ravel()
+        output = fista(objective, grad, prox, step_size=None, x0=z0_i,
                        adaptive_step_size=True, timing=timing,
                        name="Update z", **fista_kwargs)
         if timing:
@@ -206,8 +216,6 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
             z_hat, pobj = output
 
     elif solver == "lgcd":
-        if not sparse.isspmatrix_lil(f0):
-            f0 = f0.reshape(n_atoms, n_times_valid)
 
         # Default values
         tol = solver_kwargs.get('tol', 1e-3)
@@ -215,9 +223,10 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
         max_iter = solver_kwargs.get('max_iter', 1e15)
         strategy = solver_kwargs.get('strategy', 'greedy')
         output = _coordinate_descent_idx(
-            X_i, D, constants, reg=reg, z0=f0,
-            freeze_support=freeze_support, tol=tol, max_iter=max_iter,
-            n_seg=n_seg, strategy=strategy, timing=timing, name="Update z")
+            X_i, D, constants, reg=reg, z0=z0_i, max_iter=max_iter, tol=tol,
+            strategy=strategy, n_seg=n_seg, freeze_support=freeze_support,
+            timing=timing, random_state=rng, name="Update z")
+
         if timing:
             z_hat, pobj, times = output
             times[0] += init_timing

--- a/alphacsc/update_z_multi.py
+++ b/alphacsc/update_z_multi.py
@@ -210,7 +210,7 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
             f0 = f0.reshape(n_atoms, n_times_valid)
 
         # Default values
-        tol = solver_kwargs.get('tol', 1e-1)
+        tol = solver_kwargs.get('tol', 1e-3)
         n_seg = solver_kwargs.get('n_seg', 'auto')
         max_iter = solver_kwargs.get('max_iter', 1e15)
         strategy = solver_kwargs.get('strategy', 'greedy')

--- a/alphacsc/utils/coordinate_descent.py
+++ b/alphacsc/utils/coordinate_descent.py
@@ -6,6 +6,7 @@ from scipy import sparse
 
 from .lil import is_lil
 from .. import cython_code
+from . import check_random_state
 from ..loss_and_gradient import gradient_zi
 from .convolution import _choose_convolve_multi
 
@@ -13,7 +14,7 @@ from .convolution import _choose_convolve_multi
 def _coordinate_descent_idx(Xi, D, constants, reg, z0=None, max_iter=1000,
                             tol=1e-1, strategy='greedy', n_seg='auto',
                             freeze_support=False, debug=False, timing=False,
-                            name="CD", verbose=0):
+                            random_state=None, name="CD", verbose=0):
     """Compute the coding signal associated to Xi with coordinate descent.
 
     Parameters
@@ -66,6 +67,8 @@ def _coordinate_descent_idx(Xi, D, constants, reg, z0=None, max_iter=1000,
             n_seg = 1
             n_coordinates = n_times_valid * n_atoms
 
+    rng = check_random_state(random_state)
+
     max_iter *= n_seg
     n_times_seg = n_times_valid // n_seg + 1
 
@@ -105,7 +108,7 @@ def _coordinate_descent_idx(Xi, D, constants, reg, z0=None, max_iter=1000,
     for ii in range(int(max_iter)):
         k0, t0, dz = _select_coordinate(strategy, dz_opt, active_segs[i_seg],
                                         n_atoms, n_times_valid, n_times_seg,
-                                        seg_bounds)
+                                        seg_bounds, rng=rng)
         if strategy in ['random', 'cyclic']:
             # accumulate on all coordinates from the stopping criterion
             if ii % n_coordinates == 0:
@@ -250,11 +253,11 @@ def _update_beta(beta, dz_opt, accumulator, active_segs, z_hat, DtD, norm_Dk,
 
 
 def _select_coordinate(strategy, dz_opt, active_seg, n_atoms, n_times_valid,
-                       n_times_seg, seg_bounds):
+                       n_times_seg, seg_bounds, rng):
     # Pick a coordinate to update
     if strategy == 'random':
-        k0 = np.random.randint(n_atoms)
-        t0 = np.random.randint(n_times_valid)
+        k0 = rng.randint(n_atoms)
+        t0 = rng.randint(n_times_valid)
         dz = dz_opt[k0, t0]
 
     elif strategy == 'cyclic':

--- a/alphacsc/utils/coordinate_descent.py
+++ b/alphacsc/utils/coordinate_descent.py
@@ -84,8 +84,8 @@ def _coordinate_descent_idx(Xi, D, constants, reg, z0=None, max_iter=1000,
         pobj = [objective(z_hat)]
         t_start = time.time()
 
-    beta, dz_opt = _init_beta(Xi, z_hat, D, constants, reg, norm_Dk,
-                              tol, use_sparse_dz=False)
+    beta, dz_opt, tol = _init_beta(Xi, z_hat, D, constants, reg, norm_Dk,
+                                   tol, use_sparse_dz=False)
 
     # If we freeze the support, we put dz_opt to zero outside the support of z0
     if freeze_support:
@@ -186,11 +186,12 @@ def _init_beta(Xi, z_hat, D, constants, reg, norm_Dk, tol,
     else:
         dz_opt = np.maximum(-beta - reg, 0) / norm_Dk - z_hat
 
+    tol = tol * np.std(Xi)
     if use_sparse_dz:
         dz_opt[abs(dz_opt) < tol] = 0
         dz_opt = sparse.lil_matrix(dz_opt)
 
-    return beta, dz_opt
+    return beta, dz_opt, tol
 
 
 def _update_beta(beta, dz_opt, accumulator, active_segs, z_hat, DtD, norm_Dk,

--- a/alphacsc/utils/tests/test_optim.py
+++ b/alphacsc/utils/tests/test_optim.py
@@ -20,7 +20,7 @@ def test_ista():
     def grad(x):
         return A.T.dot(A.dot(x) - b)
 
-    def prox(x):
+    def prox(x, step_size=0):
         return x / max(np.linalg.norm(x), 1.)
 
     x0 = np.random.rand(p)


### PR DESCRIPTION
The scaling `X / X.std()` is needed to avoid numerical issues in the optimization but it is not really necessary. It would be nice to make the optimization more robust to sucha scaling issue.
For the Z-step, the optimization is not really impacted, only the stopping criterions are. I propose to correctly scale the tolerance parameter in `lgcd` to make it independent of the scale.
For the d/uv-steps, the norm of the gradient might be too low when using unscaled MEG signals. To make is more friendly for practitioners, I implemented a scaling for the optimization inside `learn_d_z_multi`. This does not change the results but makes the optimization more robust. The main issue with this is that it breaks the equivalence between successive `partial_fit` and an online fit if the `std` of the signals are not unitary. But I would say it is not a big issue.

Closes #6