### PR TITLE
EXA add conditioned activation plot in multi_csc example

### DIFF
--- a/alphacsc/utils/convolution.py
+++ b/alphacsc/utils/convolution.py
@@ -70,6 +70,18 @@ def construct_X_multi(z, D=None, n_channels=None):
     return X
 
 
+def construct_sources(model, z_hat,):
+    """Compute univariate source signals using temporal atoms only."""
+    sources = []
+    for kk in range(model.v_hat_.shape[0]):
+        v_k = model.v_hat_[kk]
+        v_k_1 = np.r_[[1], v_k][None]
+        z_k = z_hat[:, kk:kk + 1]
+        X_k = construct_X_multi(z_k, v_k_1, n_channels=1)[0, 0]
+        sources.append(X_k)
+    return np.array(sources)
+
+
 def _sparse_convolve(z_i, ds):
     """Same as _dense_convolve, but use the sparsity of zi."""
     n_atoms, n_times_atom = ds.shape


### PR DESCRIPTION
I added the event-related activation figure in the multi CSC example.
It is not as cool as the one we discussed, since this set of parameter does not decompose the ERP for events 3-4 into two atoms (see below).

![Figure_3](https://user-images.githubusercontent.com/11065596/59305191-995f2d00-8c4e-11e9-9435-20322a7df80d.png)
