### PR TITLE
[WIP] mne-somato now uses BIDS format

### DIFF
--- a/alphacsc/datasets/somato.py
+++ b/alphacsc/datasets/somato.py
@@ -50,8 +50,8 @@ def load_data(dataset="somato", n_splits=10, sfreq=None, epoch=None,
         data_path = mne.datasets.somato.data_path()
         subject = '01'
         task = 'somato'
-        file_name = pjoin(data_path, 'sub-{}'.format(subject), 'meg',
-                  'sub-{}_task-{}_meg.fif'.format(subject, task))
+        file_name = join(data_path, 'sub-{}'.format(subject), 'meg',
+                         'sub-{}_task-{}_meg.fif'.format(subject, task))
         subjects_dir = join(data_path, 'derivatives', 'freesurfer',
                             'subjects')
         raw = mne.io.read_raw_fif(file_name, preload=True)
@@ -60,6 +60,7 @@ def load_data(dataset="somato", n_splits=10, sfreq=None, epoch=None,
 
         # Dipole fit information
         cov = None  # see below
+        data_dir = join(data_path, 'MEG', 'somato')  # TODO fix
         file_trans = join(data_dir, "sef_raw_sss-trans.fif")
         file_bem = join(subjects_dir, 'somato', 'bem',
                         'somato-5120-bem-sol.fif')

--- a/alphacsc/datasets/somato.py
+++ b/alphacsc/datasets/somato.py
@@ -48,9 +48,12 @@ def load_data(dataset="somato", n_splits=10, sfreq=None, epoch=None,
 
     if dataset == 'somato':
         data_path = mne.datasets.somato.data_path()
-        subjects_dir = join(data_path, "subjects")
-        data_dir = join(data_path, 'MEG', 'somato')
-        file_name = join(data_dir, 'sef_raw_sss.fif')
+        subject = '01'
+        task = 'somato'
+        file_name = pjoin(data_path, 'sub-{}'.format(subject), 'meg',
+                  'sub-{}_task-{}_meg.fif'.format(subject, task))
+        subjects_dir = join(data_path, 'derivatives', 'freesurfer',
+                            'subjects')
         raw = mne.io.read_raw_fif(file_name, preload=True)
         raw.notch_filter(np.arange(50, 101, 50), n_jobs=n_jobs)
         event_id = 1


### PR DESCRIPTION
Thank you for your awesome package @TomDLT @tomMoral 

As mentioned in https://github.com/mne-tools/mne-python/pull/6414, the format for the somato datasets changed in MNE.

If you use the development version of MNE, load_somato() will fail to find the .fif file:
```pytb
In [1]: from alphacsc.datasets import somato                                    

In [2]: somato.load_data()                                                      
Opening raw data file /home/mathurin/mne_data/MNE-somato-data/MEG/somato/sef_raw_sss.fif...
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
<ipython-input-2-33dfc86fa669> in <module>
----> 1 somato.load_data()

~/miniconda3/lib/python3.7/site-packages/joblib/memory.py in __call__(self, *args, **kwargs)
    566 
    567     def __call__(self, *args, **kwargs):
--> 568         return self._cached_call(args, kwargs)[0]
    569 
    570     def __getstate__(self):

~/miniconda3/lib/python3.7/site-packages/joblib/memory.py in _cached_call(self, args, kwargs, shelving)
    532 
    533         if must_call:
--> 534             out, metadata = self.call(*args, **kwargs)
    535             if self.mmap_mode is not None:
    536                 # Memmap the output at the first call to be consistent with

~/miniconda3/lib/python3.7/site-packages/joblib/memory.py in call(self, *args, **kwargs)
    732         if self._verbose > 0:
    733             print(format_call(self.func, args, kwargs))
--> 734         output = self.func(*args, **kwargs)
    735         self.store_backend.dump_item(
    736             [func_id, args_id], output, verbose=self._verbose)

~/workspace/alphacsc/alphacsc/datasets/somato.py in load_data(dataset, n_splits, sfreq, epoch, filter_params, return_array, n_jobs)
     52         data_dir = join(data_path, 'MEG', 'somato')
     53         file_name = join(data_dir, 'sef_raw_sss.fif')
---> 54         raw = mne.io.read_raw_fif(file_name, preload=True)
     55         raw.notch_filter(np.arange(50, 101, 50), n_jobs=n_jobs)
     56         event_id = 1

~/workspace/mne-python/mne/io/fiff/raw.py in read_raw_fif(fname, allow_maxshield, preload, verbose)
    457     """
    458     return Raw(fname=fname, allow_maxshield=allow_maxshield,
--> 459                preload=preload, verbose=verbose)

</home/mathurin/workspace/mne-python/mne/externals/decorator.py:decorator-gen-165> in __init__(self, fname, allow_maxshield, preload, verbose)

~/workspace/mne-python/mne/utils/_logging.py in wrapper(*args, **kwargs)
     88             with use_log_level(verbose_level):
     89                 return function(*args, **kwargs)
---> 90         return function(*args, **kwargs)
     91     return FunctionMaker.create(
     92         function, 'return decfunc(%(signature)s)',

~/workspace/mne-python/mne/io/fiff/raw.py in __init__(self, fname, allow_maxshield, preload, verbose)
     78             raw, next_fname, buffer_size_sec = \
     79                 self._read_raw_file(next_fname, allow_maxshield,
---> 80                                     preload, do_check_fname)
     81             do_check_fname = False
     82             raws.append(raw)

</home/mathurin/workspace/mne-python/mne/externals/decorator.py:decorator-gen-166> in _read_raw_file(self, fname, allow_maxshield, preload, do_check_fname, verbose)

~/workspace/mne-python/mne/utils/_logging.py in wrapper(*args, **kwargs)
     88             with use_log_level(verbose_level):
     89                 return function(*args, **kwargs)
---> 90         return function(*args, **kwargs)
     91     return FunctionMaker.create(
     92         function, 'return decfunc(%(signature)s)',

~/workspace/mne-python/mne/io/fiff/raw.py in _read_raw_file(self, fname, allow_maxshield, preload, do_check_fname, verbose)
    145             whole_file = True
    146         fname_rep = _get_fname_rep(fname)
--> 147         ff, tree, _ = fiff_open(fname, preload=whole_file)
    148         with ff as fid:
    149             #   Read the measurement info

</home/mathurin/workspace/mne-python/mne/externals/decorator.py:decorator-gen-6> in fiff_open(fname, preload, verbose)

~/workspace/mne-python/mne/utils/_logging.py in wrapper(*args, **kwargs)
     88             with use_log_level(verbose_level):
     89                 return function(*args, **kwargs)
---> 90         return function(*args, **kwargs)
     91     return FunctionMaker.create(
     92         function, 'return decfunc(%(signature)s)',

~/workspace/mne-python/mne/io/open.py in fiff_open(fname, preload, verbose)
    118         A list of tags.
    119     """
--> 120     fid = _fiff_get_fid(fname)
    121     # do preloading of entire file
    122     if preload:

~/workspace/mne-python/mne/io/open.py in _fiff_get_fid(fname)
     49         else:
     50             logger.debug('Using normal I/O')
---> 51             fid = open(fname, "rb")  # Open in binary mode
     52     return fid
     53 

FileNotFoundError: [Errno 2] No such file or directory: '/home/mathurin/mne_data/MNE-somato-data/MEG/somato/sef_raw_sss.fif'
```


I have updated the paths for raw and subjects_dir, but I don't know where the `-trans.fif` and the `somato-5120-bem-sol` files went, so this is WIP.