### PR TITLE
Test for python3.8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '3.8'
       - name: Run flake8
         run: |
-          pip install flake8==3.6.0
+          pip install flake8==3.8.0
           flake8 --exclude=alphacsc/other/ --count alphacsc

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.6]
+        python: [3.8]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -25,10 +25,10 @@ jobs:
           conda --version
           which python
           pip install numpy cython
-          pip install -e .
           pip install pytest">=3.6" coverage pytest-cov coveralls
       - name: Run unit tests
         run: |
+          pip install -e .
           pytest --cov=alphacsc --cov-report=xml
       - name: Upload coverage
         uses: codecov/codecov-action@v1

--- a/alphacsc/datasets/hcp.py
+++ b/alphacsc/datasets/hcp.py
@@ -221,7 +221,7 @@ def make_array(X, equalize='zeropad'):
                            axis=-1) for x in X
         ])
     else:
-        raise ValueError(f"The equalize parameter should be in "
+        raise ValueError("The equalize parameter should be in "
                          f"{'crop', 'zeropad'}, got '{equalize}'.")
 
     return X

--- a/alphacsc/datasets/hcp.py
+++ b/alphacsc/datasets/hcp.py
@@ -221,7 +221,7 @@ def make_array(X, equalize='zeropad'):
                            axis=-1) for x in X
         ])
     else:
-        raise ValueError("The equalize '{}' is not valid. It should be in "
-                         "{'crop', 'zeropad'}".format(equalize))
+        raise ValueError(f"The equalize '{equalize}' is not valid. "
+                         "It should be in {'crop', 'zeropad'}")
 
     return X

--- a/alphacsc/datasets/hcp.py
+++ b/alphacsc/datasets/hcp.py
@@ -221,7 +221,7 @@ def make_array(X, equalize='zeropad'):
                            axis=-1) for x in X
         ])
     else:
-        raise ValueError(f"The equalize '{equalize}' is not valid. "
-                         "It should be in {'crop', 'zeropad'}")
+        raise ValueError(f"The equalize parameter should be in "
+                         f"{'crop', 'zeropad'}, got '{equalize}'.")
 
     return X

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -145,8 +145,8 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
     """
 
     assert lmbd_max in ['fixed', 'scaled', 'per_atom', 'shared'], (
-        "lmbd_max should be in {'fixed', 'scaled', 'per_atom', 'shared'}"
-        f"not '{lmbd_max}'"
+        "lmbd_max should be in {'fixed', 'scaled', 'per_atom', 'shared'}, "
+        f"got '{lmbd_max}'"
     )
 
     n_trials, n_channels, n_times = check_dimension(X)

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -145,8 +145,8 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
     """
 
     assert lmbd_max in ['fixed', 'scaled', 'per_atom', 'shared'], (
-        "lmbd_max should be in {'fixed', 'scaled', 'per_atom', 'shared'}, "
-        "not '{}'".format(lmbd_max)
+        "lmbd_max should be in {'fixed', 'scaled', 'per_atom', 'shared'}"
+        f"not '{lmbd_max}'"
     )
 
     n_trials, n_channels, n_times = check_dimension(X)

--- a/alphacsc/utils/arma.py
+++ b/alphacsc/utils/arma.py
@@ -42,6 +42,7 @@ class Arma(object):
         If True, the amplitude is normalized
 
     """
+
     def __init__(self, ordar=2, ordma=0, block_length=1024, fft_length=None,
                  step=None, wfunc=np.hamming, fs=1., donorm=True):
         self.ordar = ordar
@@ -124,7 +125,7 @@ class Arma(object):
             count = 0
             while block[-1] < sig.size:
                 psd[i] += np.abs(
-                    fft(window * sig[block], fft_length, 0))[:n_freq] ** 2
+                    fft.fft(window * sig[block], fft_length, 0))[:n_freq] ** 2
                 count = count + 1
                 block = block + step
             if count == 0:


### PR DESCRIPTION
Update workflows to use Python 3.8.
Fix problems while testing with Python3.8
Fix linting for Python3.8

Tests run without problems for 3.7 as well.