### PR TITLE
Deploy GitHub pages

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -3,7 +3,9 @@ name: Deploy GitHub pages
 on:
   pull_request:
   push:
+    branches: master
 
+    
 jobs:
   build_docs:
     runs-on: ubuntu-latest
@@ -24,4 +26,33 @@ jobs:
         with:
           name: DocHTML
           path: doc/_build/html/
-          
+
+  deploy_docs:
+    if: github.ref == 'refs/heads/master'
+    needs:
+      build_docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: DocHTML
+          path: doc/_build/html/
+      - name: Commit to documentation repo
+        run: |
+          git clone --no-checkout --depth 1 https://github.com/alphacsc/alphacsc.github.io.git --branch master --single-branch gh-pages
+          cp -r doc/_build/html/* gh-pages/
+          cd gh-pages
+          touch .nojekyll
+          git config --local user.email "alphacsc@github.com"
+          git config --local user.name "alphacsc GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true
+      - name: Push changes
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          repository: alphacsc/alphacsc.github.io
+          branch: master
+          directory: gh-pages
+          github_token: ${{ secrets.DEPLOY_PAGES }}

--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -14,8 +14,10 @@ jobs:
         with:
           docs-folder: "doc/"
           pre-build-command: |
-            python -m pip install numpy cython
-            python -m pip install -e .[doc]
+            apt-get update
+            apt-get install -y gcc
+            pip install numpy cython
+            pip install -e .[doc]
       - name:  Upload generated HTML as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -15,9 +15,10 @@ jobs:
           docs-folder: "doc/"
           pre-build-command: |
             apt-get update
-            apt-get install -y gcc
+            apt-get install -y gcc git
             pip install numpy cython
             pip install -e .[doc]
+            pip install git+https://github.com/mne-tools/mne-python.git@main
       - name:  Upload generated HTML as artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -1,0 +1,24 @@
+name: Deploy GitHub pages
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate HTML docs
+        uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "doc/"
+          pre-build-command: |
+            python -m pip install numpy cython
+            python -m pip install -e .[doc]
+      - name:  Upload generated HTML as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: DocHTML
+          path: doc/_build/html/
+          

--- a/alphacsc/datasets/somato.py
+++ b/alphacsc/datasets/somato.py
@@ -48,18 +48,17 @@ def load_data(dataset="somato", n_splits=10, sfreq=None, epoch=None,
 
     if dataset == 'somato':
         data_path = mne.datasets.somato.data_path()
-        subjects_dir = join(data_path, "subjects")
-        data_dir = join(data_path, 'MEG', 'somato')
-        file_name = join(data_dir, 'sef_raw_sss.fif')
+        subjects_dir = None
+        file_name = join(data_path, 'sub-01', 'meg',
+                         'sub-01_task-somato_meg.fif')
         raw = mne.io.read_raw_fif(file_name, preload=True)
         raw.notch_filter(np.arange(50, 101, 50), n_jobs=n_jobs)
         event_id = 1
 
         # Dipole fit information
         cov = None  # see below
-        file_trans = join(data_dir, "sef_raw_sss-trans.fif")
-        file_bem = join(subjects_dir, 'somato', 'bem',
-                        'somato-5120-bem-sol.fif')
+        file_trans = None
+        file_bem = None
 
     elif dataset == 'sample':
         data_path = mne.datasets.sample.data_path()

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,7 +5,6 @@ Contents
 .. toctree::
 	:maxdepth: 2
 
-	index
 	models
 	auto_examples/index
 	api

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst
 
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ doc =
     sphinx_bootstrap_theme
     sphinx_gallery
     pactools
+    nibabel
 
 dev =
     flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,12 @@ test =
      pytest
      pytest-cov
 
+doc =
+    numpydoc
+    sphinx_bootstrap_theme
+    sphinx_gallery
+    pactools
+
 dev =
     flake8
 


### PR DESCRIPTION
Adds Github action to build the docs and deploy to github pages.

A token should be generated and added to alphacsc project secrets with name DEPLOY_PAGES.

Addresses issue #34. 

Fixes mne-somato problems mentioned in pull request #28 to be able to run the examples. 