### PR TITLE
 build: use PEP517/518 conventions

### DIFF
--- a/.github/workflows/deploy_ghpages.yml
+++ b/.github/workflows/deploy_ghpages.yml
@@ -18,7 +18,6 @@ jobs:
           pre-build-command: |
             apt-get update
             apt-get install -y gcc git
-            pip install numpy cython
             pip install -e .[doc]
             pip install git+https://github.com/mne-tools/mne-python.git@main
       - name:  Upload generated HTML as artifact

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           conda --version
           which python
-          pip install numpy cython
           pip install -e .[test]
       - name: Run unit tests
         run: |

--- a/README.rst
+++ b/README.rst
@@ -28,14 +28,12 @@ install this package, please run one of the two commands:
 
 .. code::
 
-    pip install numpy cython
     pip install alphacsc
 
 (Development version)
 
 .. code::
 
-	pip install numpy cython
 	pip install git+https://github.com/alphacsc/alphacsc.git#egg=alphacsc
 
 If you do not have admin privileges on the computer, use the ``--user`` flag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 # pyproject.toml
 [build-system]
-requires = ['setuptools', 'wheel', 'numpy', 'Cython']
+requires = [
+  "setuptools>=42", # https://github.com/pypa/setuptools/issues/2312
+  'wheel',
+  "oldest-supported-numpy", # https://github.com/scipy/oldest-supported-numpy
+  'Cython',
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,41 @@
 [metadata]
-description_file = README.rst
+name = alphacsc
+version = attr: alphacsc.__version__
+description = Convolutional dictionary learning for noisy signals.
+maintainer = Mainak Jas
+author_email = mainakjas@gmail.com
+license = BSD (3-clause)
+url = https://github.com/alphacsc/alphacsc.git
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+classifiers =
+    Intended Audience :: Science/Research
+    Intended Audience :: Developers
+    License :: OSI Approved
+    Programming Language :: Python
+    Topic :: Software Development
+    Topic :: Scientific/Engineering
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Operating System :: Unix
+    Operating System :: MacOS
+platforms = any
+
+[options]
+zip_safe = True
+include_package_data = True
+install_requires =
+    mne
+    numba
+    numpy
+    scipy
+    joblib
+    matplotlib
+    scikit-learn
+packages = find:
+
+[options.packages.find]
+exclude = tests
 
 
 [options.extras_require]
@@ -19,11 +55,10 @@ dev =
 
 [flake8]
 exclude =
-     .git,
+    .git,
     __pycache__,
     alphacsc/other,
     examples/
     benchmarks/
-
 count = True
 

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,11 @@ VERSION = find_version()
 # Add cython extensions
 kmc2 = Extension('alphacsc.other.kmc2.kmc2',
                  sources=['alphacsc/other/kmc2/kmc2.pyx'],
-                 extra_compile_args=['-O3'])
+                 extra_compile_args=['-O3'],
+                 include_dirs=[np.get_include()])
 sdtw = Extension('alphacsc.other.sdtw.soft_dtw_fast',
-                 sources=['alphacsc/other/sdtw/soft_dtw_fast.pyx'])
+                 sources=['alphacsc/other/sdtw/soft_dtw_fast.pyx'],
+                 include_dirs=[np.get_include()])
 modules = [kmc2, sdtw]
 
 # Create the alphacsc.cython modules
@@ -47,42 +49,10 @@ other_modules = [
 for m in other_modules:
     modules.append(
         Extension("alphacsc.cython_code.{}".format(m),
-                  sources=["alphacsc/cython_code/{}.pyx".format(m)]))
-ext_modules = cythonize(modules)
+                  sources=["alphacsc/cython_code/{}.pyx".format(m)],
+                  include_dirs=[np.get_include()]))
 
 if __name__ == "__main__":
-    setup(
-        name=DISTNAME,
-        maintainer=MAINTAINER,
-        maintainer_email=MAINTAINER_EMAIL,
-        description=DESCRIPTION,
-        license=LICENSE,
-        version=VERSION,
-        download_url=DOWNLOAD_URL,
-        long_description=open('README.rst').read(),
-        classifiers=[
-            'Intended Audience :: Science/Research',
-            'Intended Audience :: Developers',
-            'License :: OSI Approved',
-            'Programming Language :: Python',
-            'Topic :: Software Development',
-            'Topic :: Scientific/Engineering',
-            'Operating System :: Microsoft :: Windows',
-            'Operating System :: POSIX',
-            'Operating System :: Unix',
-            'Operating System :: MacOS',
-        ],
-        platforms='any',
-        ext_modules=ext_modules,
-        packages=find_packages(exclude=["tests"]),
-        setup_requires=['Cython', 'numpy'],
-        install_requires=[
-            'mne',
-            'numba',
-            'numpy',
-            'scipy',
-            'joblib',
-            'matplotlib',
-            'scikit-learn',
-        ],
-        include_dirs=[np.get_include()], )
+    from Cython.Build import cythonize
+
+    setup(ext_modules=cythonize(modules))

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,7 @@
 #! /usr/bin/env python
-import os
-import re
+from setuptools import setup, Extension
 import numpy as np
-from Cython.Build import cythonize
-from setuptools import setup, Extension, find_packages
 
-descr = """Convolutional dictionary learning for noisy signals"""
-
-DISTNAME = 'alphacsc'
-DESCRIPTION = descr
-MAINTAINER = 'Mainak Jas'
-MAINTAINER_EMAIL = 'mainakjas@gmail.com'
-LICENSE = 'BSD (3-clause)'
-DOWNLOAD_URL = 'https://github.com/alphacsc/alphacsc.git'
-
-
-# Function to parse __version__ in `alphacsc`
-def find_version():
-    here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, 'alphacsc', '__init__.py'), 'r') as fp:
-        version_file = fp.read()
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
-                              version_file, re.M)
-    if version_match:
-        return version_match.group(1)
-    raise RuntimeError("Unable to find version string.")
-
-
-VERSION = find_version()
 
 # Add cython extensions
 kmc2 = Extension('alphacsc.other.kmc2.kmc2',


### PR DESCRIPTION
Hello everyone,

In this PR, I propose to slightly change the build process to follow [PEP 517](https://www.python.org/dev/peps/pep-0517/) and [PEP 518](https://www.python.org/dev/peps/pep-0518/).

### `setup.cfg` and `pyproject.toml`
The now standartized way to package library is using `setup.cfg`, `pyproject.toml` (and optionally `setup.py`). Basically, all that is needed to build the package is installed in a separate virtualenv, the package is then build (in a wheel format) and the virtualenv is removed. Build dependencies (such as cython) do not remain in the user's workspace any more.

To that end, I moved most of `setup.py`'s content into `setup.cfg`. Infortunately, the cython extensions could not be adapted, so they remained in `setup.py`.

To build and install `alphacsc':
```
# for a normal installation
python -m pip install . 
# for an editable installation
python -m pip install -e .
# to also install the test librairies
python -m pip install -e .[test]
```
(Note that the `python -m` can be omitted most of the times.)
The old way of building and installing (`python setup.py install`) will not work any more.

### Version number

I removed the function that parsed the version number (`find_version()` in `setup.py`) as this can be done automatically with the following line in `setup.cfg`:

```yaml
version = attr: alphacsc.__version__
```

### Workflows

It is not needed to separately install cython and numpy beforehand, therefore all lines `pip install numpy cython` are removed from worflows and documentation.