### PR TITLE
Update compute_d _func

### DIFF
--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -180,7 +180,7 @@ class BaseZEncoder:
         self.n_atoms = n_atoms
         self.atom_support = atom_support
         self.n_jobs = n_jobs
-        self.z_alg = solver
+        self.solver = solver
 
         self.solver_kwargs = solver_kwargs
         self.algorithm = algorithm
@@ -370,7 +370,7 @@ class AlphaCSCEncoder(BaseZEncoder):
             self.D_hat,
             reg=reg,
             z0=z0,
-            solver=self.z_alg,
+            solver=self.solver,
             solver_kwargs=self.solver_kwargs,
             freeze_support=unbiased_z_hat,
             loss=self.loss,

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -183,9 +183,7 @@ class BaseZEncoder:
         self.n_trials, self.n_channels, self.n_times = X.shape
         self.n_times_valid = self.n_times - self.atom_support + 1
 
-        self.constants = {}
-        self.constants['n_channels'] = self.n_channels
-        self.constants['XtX'] = np.dot(X.ravel(), X.ravel())
+        self.XtX = np.dot(X.ravel(), X.ravel())
 
     def compute_z(self):
         """
@@ -278,7 +276,10 @@ class BaseZEncoder:
         """
         """
 
-        return self.constants
+        return dict(n_channels=self.n_channels,
+                    XtX=self.XtX,
+                    ztz=self.ztz,
+                    ztX=self.ztX)
 
     def add_one_atom(self, new_atom):
         """
@@ -369,22 +370,23 @@ class AlphaCSCEncoder(BaseZEncoder):
             return_ztz=True)
 
     def compute_z(self, unbiased_z_hat=False):
-        self.z_hat, self.constants['ztz'], self.constants['ztX'] = self._compute_z_aux(  # noqa
-            self.X, self.z_hat, unbiased_z_hat)
+        self.z_hat, self.ztz, self.ztX = self._compute_z_aux(self.X,
+                                                             self.z_hat,
+                                                             unbiased_z_hat)
 
     def compute_z_partial(self, i0, alpha=.8):
-        if 'ztz' not in self.constants:
-            self.constants['ztz'] = np.zeros(
+        if not hasattr(self, 'ztz'):
+            self.ztz = np.zeros(
                 (self.n_atoms, self.n_atoms, 2 * self.atom_support - 1))
-        if 'ztX' not in self.constants:
-            self.constants['ztX'] = np.zeros(
+        if not hasattr(self, 'ztX'):
+            self.ztX = np.zeros(
                 (self.n_atoms, self.n_channels, self.atom_support))
 
         self.z_hat[i0], self.ztz_i0, self.ztX_i0 = self._compute_z_aux(
             self.X[i0], self.z_hat[i0], unbiased_z_hat=False)
 
-        self.constants['ztz'] = alpha * self.constants['ztz'] + self.ztz_i0
-        self.constants['ztX'] = alpha * self.constants['ztX'] + self.ztX_i0
+        self.ztz = alpha * self.ztz + self.ztz_i0
+        self.ztX = alpha * self.ztX + self.ztX_i0
 
     def get_cost(self):
         cost = compute_X_and_objective_multi(self.X,
@@ -399,10 +401,10 @@ class AlphaCSCEncoder(BaseZEncoder):
         return cost
 
     def get_sufficient_statistics(self):
-        assert 'ztz' in self.constants and 'ztX' in self.constants, (
+        assert hasattr(self, 'ztz') and hasattr(self, 'ztX'), (
             'compute_z should be called to access the statistics.'
         )
-        return self.constants['ztz'], self.constants['ztX']
+        return self.ztz, self.ztX
 
     def get_sufficient_statistics_partial(self):
         assert hasattr(self, 'ztz_i0') and hasattr(self, 'ztX_i0'), (
@@ -531,7 +533,8 @@ class DicodileEncoder(BaseZEncoder):
         assert hasattr(self, 'run_statistics'), (
             'compute_z should be called to access the statistics.'
         )
-        return self._encoder.get_sufficient_statistics()
+        self.ztz, self.ztX = self._encoder.get_sufficient_statistics()
+        return self.ztz, self.ztX
 
     def get_sufficient_statistics_partial(self):
         """

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -466,14 +466,13 @@ class DicodileEncoder(BaseZEncoder):
         )
 
         n_times = X.shape[2]
-        self.X = X[0]
         self.D_hat = D_hat
         self.n_times_valid = n_times - atom_support + 1
         self.n_atoms = n_atoms
         self.atom_support = atom_support
         self.algorithm = algorithm
 
-        tol = DEFAULT_TOL_Z * np.std(self.X)
+        tol = DEFAULT_TOL_Z * np.std(self.X[0])
 
         params = dicodile._dicodile.DEFAULT_DICOD_KWARGS.copy()
         # DiCoDiLe defaults
@@ -484,7 +483,7 @@ class DicodileEncoder(BaseZEncoder):
                       freeze_support=False, random_state=None)
         params.update(solver_kwargs)
         self.params = params
-        self._encoder.init_workers(self.X, self.D_hat, reg, self.params)
+        self._encoder.init_workers(self.X[0], self.D_hat, reg, self.params)
 
     def compute_z(self):
         """
@@ -518,7 +517,7 @@ class DicodileEncoder(BaseZEncoder):
 
         # If compute_z has not been run, return the value of cost function when
         # z_hat = 0
-        return 0.5 * np.linalg.norm(self.X) ** 2
+        return 0.5 * np.linalg.norm(self.X[0]) ** 2
 
     def get_sufficient_statistics(self):
         """

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -146,9 +146,11 @@ def get_z_encoder_for(
             n_atoms,
             atom_support,
             n_jobs,
+            solver,
             solver_kwargs,
             algorithm,
-            reg
+            reg,
+            loss
         )
     else:
         raise ValueError(f'unrecognized solver type: {solver}.')
@@ -441,15 +443,28 @@ class DicodileEncoder(BaseZEncoder):
             n_atoms,
             atom_support,
             n_jobs,
+            solver,
             solver_kwargs,
             algorithm,
-            reg):
+            reg,
+            loss):
         try:
             import dicodile
         except ImportError as ie:
             raise ImportError(
                 'Please install DiCoDiLe by running '
                 '"pip install alphacsc[dicodile]"') from ie
+
+        super().__init__(X,
+                         D_hat,
+                         n_atoms,
+                         atom_support,
+                         n_jobs,
+                         solver,
+                         solver_kwargs,
+                         algorithm,
+                         reg,
+                         loss)
 
         self._encoder = dicodile.update_z.distributed_sparse_encoder.DistributedSparseEncoder(  # noqa: E501
             n_workers=n_jobs)

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -281,7 +281,7 @@ class BaseZEncoder:
     def get_constants(self):
         """
         """
-        raise NotImplementedError()
+        return self.constants
 
     def add_one_atom(self, new_atom):
         """
@@ -422,9 +422,6 @@ class AlphaCSCEncoder(BaseZEncoder):
 
     def set_reg(self, reg):
         self.reg = reg
-
-    def get_constants(self):
-        return self.constants
 
     def add_one_atom(self, new_atom):
         assert new_atom.shape == (self.atom_support + self.X.shape[1],)

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -146,7 +146,6 @@ def get_z_encoder_for(
             n_atoms,
             atom_support,
             n_jobs,
-            solver,
             solver_kwargs,
             algorithm,
             reg,
@@ -165,22 +164,16 @@ class BaseZEncoder:
             n_atoms,
             atom_support,
             n_jobs,
-            solver,
             solver_kwargs,
             algorithm,
             reg,
-            loss,
-            loss_params,
-            uv_constraint,
-            feasible_evaluation,
-            use_sparse_z):
+            loss):
 
         self.X = X
         self.D_hat = D_hat
         self.n_atoms = n_atoms
         self.atom_support = atom_support
         self.n_jobs = n_jobs
-        self.solver = solver
 
         self.solver_kwargs = solver_kwargs
         self.algorithm = algorithm
@@ -284,6 +277,7 @@ class BaseZEncoder:
     def get_constants(self):
         """
         """
+
         return self.constants
 
     def add_one_atom(self, new_atom):
@@ -328,19 +322,15 @@ class AlphaCSCEncoder(BaseZEncoder):
                          n_atoms,
                          atom_support,
                          n_jobs,
-                         solver,
                          solver_kwargs,
                          algorithm,
                          reg,
-                         loss,
-                         loss_params,
-                         uv_constraint,
-                         feasible_evaluation,
-                         use_sparse_z)
+                         loss)
 
         if loss_params is None:
             loss_params = dict(gamma=.1, sakoe_chiba_band=10, ordar=10)
 
+        self.solver = solver
         self.loss_params = loss_params
         self.uv_constraint = uv_constraint
         self.feasible_evaluation = feasible_evaluation
@@ -443,7 +433,6 @@ class DicodileEncoder(BaseZEncoder):
             n_atoms,
             atom_support,
             n_jobs,
-            solver,
             solver_kwargs,
             algorithm,
             reg,
@@ -460,7 +449,6 @@ class DicodileEncoder(BaseZEncoder):
                          n_atoms,
                          atom_support,
                          n_jobs,
-                         solver,
                          solver_kwargs,
                          algorithm,
                          reg,

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -179,6 +179,7 @@ class BaseZEncoder:
         self.atom_support = atom_support
         self.n_jobs = n_jobs
         self.z_alg = solver
+
         self.solver_kwargs = solver_kwargs
         self.algorithm = algorithm
         self.reg = reg

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -1,7 +1,7 @@
 import numpy as np
 from .loss_and_gradient import compute_X_and_objective_multi
 from .update_z_multi import update_z_multi
-from .utils import check_dimension, lil
+from .utils import lil
 
 DEFAULT_TOL_Z = 1e-3
 

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -424,6 +424,9 @@ class AlphaCSCEncoder(BaseZEncoder):
     def set_reg(self, reg):
         self.reg = reg
 
+    def get_constants(self):
+        return self.constants
+
     def add_one_atom(self, new_atom):
         assert new_atom.shape == (self.atom_support + self.X.shape[1],)
         self.D_hat = np.concatenate([self.D_hat, new_atom[None]])

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -493,6 +493,7 @@ class DicodileEncoder(BaseZEncoder):
         This is the "main" function of the algorithm.
         """
         self.run_statistics = self._encoder.process_z_hat()
+        self.ztz, self.ztX = self._encoder.get_sufficient_statistics()
 
     def compute_z_partial(self, i0):
         """
@@ -533,7 +534,6 @@ class DicodileEncoder(BaseZEncoder):
         assert hasattr(self, 'run_statistics'), (
             'compute_z should be called to access the statistics.'
         )
-        self.ztz, self.ztX = self._encoder.get_sufficient_statistics()
         return self.ztz, self.ztX
 
     def get_sufficient_statistics_partial(self):

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -424,9 +424,6 @@ class AlphaCSCEncoder(BaseZEncoder):
     def set_reg(self, reg):
         self.reg = reg
 
-    def get_constants(self):
-        return self.constants
-
     def add_one_atom(self, new_atom):
         assert new_atom.shape == (self.atom_support + self.X.shape[1],)
         self.D_hat = np.concatenate([self.D_hat, new_atom[None]])

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -193,7 +193,10 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
         # for D.
         d_kwargs["max_iter"] = 1
 
-    def compute_d_func(X, z_hat, D_hat, constants):
+    def compute_d_func(z_encoder, constants):
+        X = z_encoder.X
+        z_hat = z_encoder.get_z_hat()
+        D_hat = z_encoder.D_hat
         if rank1:
             return update_uv(X, z_hat, uv_hat0=D_hat, constants=constants,
                              b_hat_0=b_hat_0, solver_d=solver_d,
@@ -370,7 +373,7 @@ def _batch_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
 
         # Compute D update
         start = time.time()
-        D_hat = compute_d_func(X, z_hat, z_encoder.D_hat, constants)
+        D_hat = compute_d_func(z_encoder, constants)
         z_encoder.set_D(D_hat)
 
         # monitor cost function
@@ -476,7 +479,7 @@ def _online_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
 
         # Compute D update
         start = time.time()
-        D_hat = compute_d_func(X, z_hat, D_hat, constants)
+        D_hat = compute_d_func(z_encoder, constants)
         z_encoder.set_D(D_hat)
 
         # monitor cost function

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -229,10 +229,7 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
 
         # common parameters
         kwargs = dict(
-            X=X,
-            D_hat=D_hat,
             z_encoder=z_encoder,
-            n_atoms=n_atoms,
             compute_d_func=compute_d_func,
             end_iter_func=end_iter_func,
             n_iter=n_iter,
@@ -292,11 +289,13 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
     return pobj, times, D_hat, z_hat, reg
 
 
-def _batch_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
-                 end_iter_func, n_iter=100,
+def _batch_learn(z_encoder, compute_d_func, end_iter_func, n_iter=100,
                  lmbd_max='fixed', reg=None, verbose=0, greedy=False,
                  random_state=None, name="batch", uv_constraint='separate',
                  window=False):
+
+    X = z_encoder.X
+    n_atoms = z_encoder.n_atoms
     reg_ = reg
 
     if greedy:
@@ -391,14 +390,17 @@ def _batch_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
         if end_iter_func(X, z_hat, D_hat, pobj, ii):
             break
 
-    return pobj, times, D_hat, z_encoder.get_z_hat()
+    return pobj, times, z_encoder.D_hat, z_encoder.get_z_hat()
 
 
-def _online_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
-                  end_iter_func, n_iter=100, verbose=0,
-                  random_state=None, lmbd_max='fixed', reg=None,
+def _online_learn(z_encoder, compute_d_func, end_iter_func, n_iter=100,
+                  verbose=0, random_state=None, lmbd_max='fixed', reg=None,
                   alpha=.8, batch_selection='random', batch_size=1,
                   name="online", uv_constraint='separate', window=False):
+
+    X = z_encoder.X
+    D_hat = z_encoder.D_hat
+    n_atoms = z_encoder.n_atoms
 
     reg_ = reg
 
@@ -487,7 +489,7 @@ def _online_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
         if end_iter_func(X, z_hat, D_hat, pobj, ii):
             break
 
-    return pobj, times, D_hat, z_encoder.get_z_hat()
+    return pobj, times, z_encoder.D_hat, z_encoder.get_z_hat()
 
 
 def get_iteration_func(eps, stopping_pobj, callback, lmbd_max, name, verbose,

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -193,11 +193,10 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
         # for D.
         d_kwargs["max_iter"] = 1
 
-    def compute_d_func(z_encoder):
+    def compute_d_func(z_encoder, constants):
         X = z_encoder.X
         z_hat = z_encoder.get_z_hat()
         D_hat = z_encoder.D_hat
-        constants = z_encoder.get_constants()
         if rank1:
             return update_uv(X, z_hat, uv_hat0=D_hat, constants=constants,
                              b_hat_0=b_hat_0, solver_d=solver_d,
@@ -369,7 +368,7 @@ def _batch_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
 
         # Compute D update
         start = time.time()
-        D_hat = compute_d_func(z_encoder)
+        D_hat = compute_d_func(z_encoder, constants)
         z_encoder.set_D(D_hat)
 
         # monitor cost function
@@ -465,7 +464,7 @@ def _online_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
 
         # Compute D update
         start = time.time()
-        D_hat = compute_d_func(z_encoder)
+        D_hat = compute_d_func(z_encoder, constants)
         z_encoder.set_D(D_hat)
 
         # monitor cost function

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -193,10 +193,11 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
         # for D.
         d_kwargs["max_iter"] = 1
 
-    def compute_d_func(z_encoder, constants):
+    def compute_d_func(z_encoder):
         X = z_encoder.X
         z_hat = z_encoder.get_z_hat()
         D_hat = z_encoder.D_hat
+        constants = z_encoder.get_constants()
         if rank1:
             return update_uv(X, z_hat, uv_hat0=D_hat, constants=constants,
                              b_hat_0=b_hat_0, solver_d=solver_d,
@@ -368,7 +369,7 @@ def _batch_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
 
         # Compute D update
         start = time.time()
-        D_hat = compute_d_func(z_encoder, constants)
+        D_hat = compute_d_func(z_encoder)
         z_encoder.set_D(D_hat)
 
         # monitor cost function
@@ -464,7 +465,7 @@ def _online_learn(X, D_hat, z_encoder, n_atoms, compute_d_func,
 
         # Compute D update
         start = time.time()
-        D_hat = compute_d_func(z_encoder, constants)
+        D_hat = compute_d_func(z_encoder)
         z_encoder.set_D(D_hat)
 
         # monitor cost function


### PR DESCRIPTION
Updates `compute_d_func` to give z_encoder instead of X, z_hat, D_hat, constants.

- I would propose to move `compute_d_func` inside z_encoder as `compute_d_update` and not change the signature of `update_uv` and `update_d`.
- As far as I remember, we had also discussed moving `get_lambda_max` and `get_max_error_dict` in encoder API.

If these are OK with you, I'll continue. However, I wonder if you would have time soon to review and merge https://github.com/alphacsc/alphacsc/pull/46. If yes, I would prefer to wait until you merge to avoid too many merge conflicts.