### PR TITLE
MNT upgrade codecov uploader

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           pytest --cov=alphacsc --cov-report=xml
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: unittests 
           fail_ci_if_error: true 


### PR DESCRIPTION
This PR upgrades the Codecov coverage uploader to v2 because v1 will soon deprecate (see [here](https://github.com/marketplace/actions/codecov#%EF%B8%8F--deprecration-of-v1)).