### PR TITLE
CLN remove lil switch+improve encoders

### DIFF
--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -1,7 +1,9 @@
 import numpy as np
-from .loss_and_gradient import compute_X_and_objective_multi
+
+from .utils.dictionary import get_D_shape
 from .update_z_multi import update_z_multi
-from .utils import lil
+from .utils.dictionary import _patch_reconstruction_error
+from .loss_and_gradient import compute_X_and_objective_multi
 
 DEFAULT_TOL_Z = 1e-3
 
@@ -12,17 +14,15 @@ def get_z_encoder_for(
         X,
         D_hat,
         n_atoms,
-        atom_support,
+        n_times_atom,
         n_jobs,
         solver='l-bfgs',
         solver_kwargs=dict(),
-        algorithm='batch',
         reg=0.1,
         loss='l2',
         loss_params=None,
         uv_constraint='auto',
-        feasible_evaluation=False,
-        use_sparse_z=False):
+        feasible_evaluation=False):
     """
     Returns a z encoder for the required solver.
 
@@ -31,13 +31,13 @@ def get_z_encoder_for(
     X : array, shape (n_trials, n_channels, n_times)
         The data on which to perform CSC.
     D_hat : array, shape (n_atoms, n_channels, n_times) or
-        (n_atoms, n_channels + atom_support)
+        (n_atoms, n_channels + n_times_atom)
         The dictionary used to encode the signal X. Can be either in the form
-        of a full rank dictionary D (n_atoms, n_channels, atom_support) or with
-        the spatial and temporal atoms uv (n_atoms, n_channels + atom_support)
+        of a full rank dictionary D (n_atoms, n_channels, n_times_atom) or with
+        the spatial and temporal atoms uv (n_atoms, n_channels + n_times_atom)
     n_atoms : int
         The number of atoms to learn.
-    atom_support : int
+    n_times_atom : int
         The support of the atom.
     n_jobs : int
         The number of parallel jobs.
@@ -46,8 +46,6 @@ def get_z_encoder_for(
         {{'l_bfgs' (default) | 'lgcd' | 'dicodile'}}.
     solver_kwargs : dict
         Additional keyword arguments to pass to update_z_multi.
-    algorithm : 'batch' (default) | 'greedy' | 'online' | 'stochastic'
-        Dictionary learning algorithm.
     reg : float
         The regularization parameter.
     loss : {{ 'l2' (default) | 'dtw' | 'whitening'}}
@@ -67,9 +65,6 @@ def get_z_encoder_for(
         If feasible_evaluation is True, it first projects on the feasible set,
         i.e. norm(uv_hat) <= 1.
         If solver_z is 'dicodile', then feasible_evaluation must be False.
-    use_sparse_z : bool, default False
-        Use sparse lil_matrices to store the activations.
-        If solver_z is 'dicodile', then use_sparse_z must be False.
 
     Returns
     -------
@@ -80,18 +75,14 @@ def get_z_encoder_for(
         'solver_kwargs should be a valid dictionary.'
     )
 
-    assert (X is not None and len(X.shape) == 3), (
+    assert (X is not None and X.ndim == 3), (
         'X should be a valid array of shape (n_trials, n_channels, n_times).'
     )
 
-    assert (D_hat is not None and len(D_hat.shape) in [2, 3]), (
+    assert (D_hat is not None and D_hat.ndim in [2, 3]), (
         'D_hat should be a valid array of shape '
         '(n_atoms, n_channels, n_times) '
-        'or (n_atoms, n_channels + atom_support).'
-    )
-
-    assert algorithm in ['batch', 'greedy', 'online', 'stochastic'], (
-        f'unrecognized algorithm type: {algorithm}.'
+        'or (n_atoms, n_channels + n_times_atom).'
     )
 
     assert reg is not None, 'reg value cannot be None.'
@@ -116,17 +107,15 @@ def get_z_encoder_for(
             X,
             D_hat,
             n_atoms,
-            atom_support,
+            n_times_atom,
             n_jobs,
             solver,
             solver_kwargs,
-            algorithm,
             reg,
             loss,
             loss_params,
             uv_constraint,
-            feasible_evaluation,
-            use_sparse_z)
+            feasible_evaluation)
     elif solver == 'dicodile':
         assert loss == 'l2', f"DiCoDiLe requires a l2 loss ('{loss}' passed)."
         assert loss_params is None, "DiCoDiLe requires loss_params=None."
@@ -136,18 +125,14 @@ def get_z_encoder_for(
         assert uv_constraint == 'auto',  (
             "DiCoDiLe requires uv_constraint=auto."
         )
-        assert use_sparse_z is False, (
-            "DiCoDiLe requires use_sparse_z=False."
-        )
 
         return DicodileEncoder(
             X,
             D_hat,
             n_atoms,
-            atom_support,
+            n_times_atom,
             n_jobs,
             solver_kwargs,
-            algorithm,
             reg,
             loss
         )
@@ -162,26 +147,24 @@ class BaseZEncoder:
             X,
             D_hat,
             n_atoms,
-            atom_support,
+            n_times_atom,
             n_jobs,
             solver_kwargs,
-            algorithm,
             reg,
             loss):
 
         self.X = X
         self.D_hat = D_hat
         self.n_atoms = n_atoms
-        self.atom_support = atom_support
+        self.n_times_atom = n_times_atom
         self.n_jobs = n_jobs
 
         self.solver_kwargs = solver_kwargs
-        self.algorithm = algorithm
         self.reg = reg
         self.loss = loss
 
         self.n_trials, self.n_channels, self.n_times = X.shape
-        self.n_times_valid = self.n_times - self.atom_support + 1
+        self.n_times_valid = self.n_times - self.n_times_atom + 1
 
         self.XtX = np.dot(X.ravel(), X.ravel())
 
@@ -226,9 +209,8 @@ class BaseZEncoder:
 
     def get_sufficient_statistics_partial(self):
         """
-        Returns the partial sufficient statistics
-        that were computed during the last call to
-        compute_z_partial.
+        Returns the partial sufficient statistics that were
+        computed during the last call to compute_z_partial.
 
         Returns
         -------
@@ -238,14 +220,37 @@ class BaseZEncoder:
         """
         raise NotImplementedError()
 
-    def get_z_hat(self):
+    def get_max_error_patch(self):
         """
-        Returns a sparse encoding of the signal.
+        Returns the patch of the signal with the largest reconstuction error.
 
         Returns
         -------
-        z_hat
-            Sparse encoding of the signal X.
+        D_k : ndarray, shape (n_channels, n_times_atom) or
+                (n_channels + n_times_atom,)
+            Patch of the residual with the largest error.
+        """
+        raise NotImplementedError()
+
+    def get_z_hat(self):
+        """
+        Returns the sparse codes of the signals.
+
+        Returns
+        -------
+        z_hat : ndarray, shape (n_trials, n_atoms, n_times_valid)
+            Sparse codes of the signal X.
+        """
+        raise NotImplementedError()
+
+    def get_z_nnz(self):
+        """
+        Return the number of non-zero activations per atoms for the signals.
+
+        Returns
+        -------
+        z_nnz : ndarray, shape (n_atoms,)
+            Ratio of non-zero activations for each atom.
         """
         raise NotImplementedError()
 
@@ -306,25 +311,22 @@ class AlphaCSCEncoder(BaseZEncoder):
             X,
             D_hat,
             n_atoms,
-            atom_support,
+            n_times_atom,
             n_jobs,
             solver,
             solver_kwargs,
-            algorithm,
             reg,
             loss,
             loss_params,
             uv_constraint,
-            feasible_evaluation,
-            use_sparse_z):
+            feasible_evaluation):
 
         super().__init__(X,
                          D_hat,
                          n_atoms,
-                         atom_support,
+                         n_times_atom,
                          n_jobs,
                          solver_kwargs,
-                         algorithm,
                          reg,
                          loss)
 
@@ -335,23 +337,17 @@ class AlphaCSCEncoder(BaseZEncoder):
         self.loss_params = loss_params
         self.uv_constraint = uv_constraint
         self.feasible_evaluation = feasible_evaluation
-        self.use_sparse_z = use_sparse_z
 
-        self._init_z_hat()
+        effective_n_atoms = self.D_hat.shape[0]
+        self.z_hat = self._get_new_z_hat(effective_n_atoms)
 
-    def _init_z_hat(self):
-
-        self.z_hat = lil.init_zeros(
-            self.use_sparse_z, self.n_trials, self.n_atoms, self.n_times_valid)
-
-        if self.algorithm == 'greedy':
-            # remove all atoms
-            self.D_hat = self.D_hat[0:0]
-            # remove all activations
-            use_sparse_z = lil.is_list_of_lil(self.z_hat)
-            n_trials, _, n_times_valid = lil.get_z_shape(self.z_hat)
-            self.z_hat = lil.init_zeros(
-                use_sparse_z, n_trials, 0, n_times_valid)
+    def _get_new_z_hat(self, n_atoms):
+        """
+        Returns a array filed with 0 with the right size for sparse codes.
+        """
+        return np.zeros((
+            self.n_trials, n_atoms, self.n_times_valid
+        ))
 
     def _compute_z_aux(self, X, z0, unbiased_z_hat):
         reg = self.reg if not unbiased_z_hat else 0
@@ -377,10 +373,10 @@ class AlphaCSCEncoder(BaseZEncoder):
     def compute_z_partial(self, i0, alpha=.8):
         if not hasattr(self, 'ztz'):
             self.ztz = np.zeros(
-                (self.n_atoms, self.n_atoms, 2 * self.atom_support - 1))
+                (self.n_atoms, self.n_atoms, 2 * self.n_times_atom - 1))
         if not hasattr(self, 'ztX'):
             self.ztX = np.zeros(
-                (self.n_atoms, self.n_channels, self.atom_support))
+                (self.n_atoms, self.n_channels, self.n_times_atom))
 
         self.z_hat[i0], self.ztz_i0, self.ztX_i0 = self._compute_z_aux(
             self.X[i0], self.z_hat[i0], unbiased_z_hat=False)
@@ -412,6 +408,26 @@ class AlphaCSCEncoder(BaseZEncoder):
         )
         return self.ztz_i0, self.ztX_i0
 
+    def get_max_error_patch(self):
+        """
+        Returns the patch of the signal with the largest reconstuction error.
+
+        Returns
+        -------
+        D_k : ndarray, shape (n_channels, n_times_atom) or
+                (n_channels + n_times_atom,)
+            Patch of the residual with the largest error.
+        """
+        patch_rec_error = _patch_reconstruction_error(
+            self.X, self.z_hat, self.D_hat
+        )
+        i0 = patch_rec_error.argmax()
+        n0, t0 = np.unravel_index(i0, patch_rec_error.shape)
+
+        n_channels = self.X.shape[1]
+        *_, n_times_atom = get_D_shape(self.D_hat, n_channels)
+        return self.X[n0, :, t0:t0 + n_times_atom][None]
+
     def set_D(self, D):
         self.D_hat = D
 
@@ -419,12 +435,27 @@ class AlphaCSCEncoder(BaseZEncoder):
         self.reg = reg
 
     def add_one_atom(self, new_atom):
-        assert new_atom.shape == (self.atom_support + self.X.shape[1],)
+        assert new_atom.shape == (self.n_times_atom + self.X.shape[1],)
         self.D_hat = np.concatenate([self.D_hat, new_atom[None]])
-        self.z_hat = lil.add_one_atom_in_z(self.z_hat)
+        self.z_hat = np.concatenate(
+            [self.z_hat, self._get_new_z_hat(1)], axis=1
+        )
 
     def get_z_hat(self):
         return self.z_hat
+
+    def get_z_nnz(self):
+        """
+        Return the number of non-zero activations per atoms for the signals.
+
+        Returns
+        -------
+        z_nnz : ndarray, shape (n_atoms,)
+            Ratio of non-zero activations for each atom.
+        """
+        z_nnz = np.sum(self.z_hat != 0, axis=(0, 2))
+        z_size = self.z_hat.size / self.z_hat.shape[1]
+        return z_nnz / z_size
 
 
 class DicodileEncoder(BaseZEncoder):
@@ -433,10 +464,9 @@ class DicodileEncoder(BaseZEncoder):
             X,
             D_hat,
             n_atoms,
-            atom_support,
+            n_times_atom,
             n_jobs,
             solver_kwargs,
-            algorithm,
             reg,
             loss):
         try:
@@ -449,10 +479,9 @@ class DicodileEncoder(BaseZEncoder):
         super().__init__(X,
                          D_hat,
                          n_atoms,
-                         atom_support,
+                         n_times_atom,
                          n_jobs,
                          solver_kwargs,
-                         algorithm,
                          reg,
                          loss)
 
@@ -469,10 +498,9 @@ class DicodileEncoder(BaseZEncoder):
 
         n_times = X.shape[2]
         self.D_hat = D_hat
-        self.n_times_valid = n_times - atom_support + 1
+        self.n_times_valid = n_times - n_times_atom + 1
         self.n_atoms = n_atoms
-        self.atom_support = atom_support
-        self.algorithm = algorithm
+        self.n_times_atom = n_times_atom
 
         tol = DEFAULT_TOL_Z * np.std(self.X[0])
 
@@ -565,6 +593,22 @@ class DicodileEncoder(BaseZEncoder):
 
         # If compute_z has not been run, return 0.
         return np.zeros([1, self.n_atoms, self.n_times_valid])
+
+    def get_z_nnz(self):
+        """
+        Return the number of non-zero activations per atoms for the signals.
+
+        Returns
+        -------
+        z_nnz : ndarray, shape (n_atoms,)
+            Ratio of non-zero activations for each atom.
+        """
+        effective_n_atoms = self.D_hat.shape[0]
+        if not hasattr(self, 'run_statistics'):
+            return np.zeros(effective_n_atoms)
+
+        z_nnz = self._encoder.get_z_nnz()
+        return z_nnz / z_nnz.shape[-1]
 
     def set_D(self, D):
         """

--- a/alphacsc/_encoder.py
+++ b/alphacsc/_encoder.py
@@ -577,7 +577,30 @@ class DicodileEncoder(BaseZEncoder):
             selected in the last call of ``compute_z_partial``
         """
         raise NotImplementedError(
-            "Partial sufficient statistics are not available in DiCoDiLe")
+            "Partial sufficient statistics are not available in DiCoDiLe"
+        )
+
+    def get_max_error_patch(self):
+        """
+        Returns the patch of the signal with the largest reconstuction error.
+
+        Returns
+        -------
+        D_k : ndarray, shape (n_channels, n_times_atom) or
+                (n_channels + n_times_atom,)
+            Patch of the residual with the largest error.
+        """
+        # XXX - this step should be implemented in dicodile
+        # See issue tommoral/dicodile#49
+        patch_rec_error = _patch_reconstruction_error(
+            self.X, self.get_z_hat(), self.D_hat
+        )
+        i0 = patch_rec_error.argmax()
+        n0, t0 = np.unravel_index(i0, patch_rec_error.shape)
+
+        n_channels = self.X.shape[1]
+        *_, n_times_atom = get_D_shape(self.D_hat, n_channels)
+        return self.X[n0, :, t0:t0 + n_times_atom][None]
 
     def get_z_hat(self):
         """

--- a/alphacsc/convolutional_dictionary_learning.py
+++ b/alphacsc/convolutional_dictionary_learning.py
@@ -35,11 +35,13 @@ DOC_FMT = """{short_desc}
         If set to True, learn rank 1 dictionary atoms.
     window : boolean
         If set to True, re-parametrizes the atoms with a temporal Tukey window.
-    uv_constraint : {{'joint' | 'separate'}}
-        The kind of norm constraint on the atoms:
+    uv_constraint : {{'joint' | 'separate' | 'auto'}}
+        The kind of norm constraint on the atoms if :code:`rank1=True`. If
+        :code:`rank1=False`, it must be 'auto', else it can be:
 
         - :code:`'joint'`: the constraint is ||[u, v]||_2 <= 1
-        - :code:`'separate'`: the constraint is ||u||_2 <= 1 and ||v||_2 <= 1
+        - :code:`'separate'`: the constraint is ||u||_2 <= 1 and ||v||_2 <= 1.
+        This is the default for rank1 with if 'auto'.
     sort_atoms : boolean
         If True, the atoms are sorted by explained variances.
 
@@ -81,9 +83,11 @@ DOC_FMT = """{short_desc}
 
     D-step parameters
 
-    solver_d : str
-        The solver to use for the d update. Options are
-        'alternate' | 'alternate_adaptive' (default) | 'joint'
+    solver_d : str (default: 'auto')
+        The solver to use for the d update. Options are:
+        {{'alternate', 'alternate_adaptive', 'joint', 'fista', 'auto'}}
+        'auto' amounts to 'fista' when :code:`rank1=False` and
+        'alternate_adaptive' for :code:`rank1=True`.
     solver_d_kwargs : dict
         Additional keyword arguments to provide to update_d
     D_init : str or array
@@ -134,9 +138,9 @@ class ConvolutionalDictionaryLearning(TransformerMixin):
 
     def __init__(self, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
                  loss='l2', loss_params=None,
-                 rank1=True, window=False, uv_constraint='separate',
+                 rank1=True, window=False, uv_constraint='auto',
                  solver_z='l_bfgs', solver_z_kwargs={},
-                 solver_d='alternate_adaptive', solver_d_kwargs={},
+                 solver_d='auto', solver_d_kwargs={},
                  reg=0.1, lmbd_max='fixed', eps=1e-10,
                  D_init=None, D_init_params={},
                  algorithm='batch', algorithm_params={},
@@ -343,8 +347,8 @@ class BatchCDL(ConvolutionalDictionaryLearning):
 
     def __init__(self, n_atoms, n_times_atom, reg=0.1, n_iter=60, n_jobs=1,
                  solver_z='lgcd', solver_z_kwargs={}, unbiased_z_hat=False,
-                 solver_d='alternate_adaptive', solver_d_kwargs={},
-                 rank1=True, window=False, uv_constraint='separate',
+                 solver_d='auto', solver_d_kwargs={},
+                 rank1=True, window=False, uv_constraint='auto',
                  lmbd_max='scaled', eps=1e-10, D_init=None, D_init_params={},
                  verbose=10, random_state=None, sort_atoms=False):
         super().__init__(
@@ -370,8 +374,8 @@ class GreedyCDL(ConvolutionalDictionaryLearning):
 
     def __init__(self, n_atoms, n_times_atom, reg=0.1, n_iter=60, n_jobs=1,
                  solver_z='lgcd', solver_z_kwargs={}, unbiased_z_hat=False,
-                 solver_d='alternate_adaptive', solver_d_kwargs={},
-                 rank1=True, window=False, uv_constraint='separate',
+                 solver_d='auto', solver_d_kwargs={},
+                 rank1=True, window=False, uv_constraint='auto',
                  lmbd_max='scaled', eps=1e-10, D_init=None, D_init_params={},
                  verbose=10, random_state=None, sort_atoms=False):
         super().__init__(

--- a/alphacsc/convolutional_dictionary_learning.py
+++ b/alphacsc/convolutional_dictionary_learning.py
@@ -11,6 +11,7 @@ from .update_z_multi import update_z_multi
 from .utils.dictionary import get_D, get_uv
 from .learn_d_z_multi import learn_d_z_multi
 from .loss_and_gradient import construct_X_multi
+from .update_d_multi import check_solver_and_constraints
 
 
 DOC_FMT = """{short_desc}
@@ -73,8 +74,6 @@ DOC_FMT = """{short_desc}
         {{'l_bfgs' (default) | 'lgcd'}}.
     solver_z_kwargs : dict
         Additional keyword arguments to pass to update_z_multi.
-    use_sparse_z : boolean
-        Use sparse lil_matrices to store the activations.
     unbiased_z_hat : boolean
         If set to True, the value of the non-zero coefficients in the returned
         z_hat are recomputed with reg=0 on the frozen support.
@@ -142,9 +141,13 @@ class ConvolutionalDictionaryLearning(TransformerMixin):
                  D_init=None, D_init_params={},
                  algorithm='batch', algorithm_params={},
                  alpha=.8, batch_size=1, batch_selection='random',
-                 use_sparse_z=False, unbiased_z_hat=False,
-                 verbose=10, callback=None, random_state=None, name="_CDL",
-                 raise_on_increase=True, sort_atoms=False):
+                 unbiased_z_hat=False, verbose=10, callback=None,
+                 random_state=None, name="_CDL", raise_on_increase=True,
+                 sort_atoms=False):
+
+        solver_d, uv_constraint = check_solver_and_constraints(
+            rank1, solver_d, uv_constraint
+        )
 
         # Problem Specs
         self.n_atoms = n_atoms
@@ -167,7 +170,6 @@ class ConvolutionalDictionaryLearning(TransformerMixin):
         # Z-step parameters
         self.solver_z = solver_z
         self.solver_z_kwargs = solver_z_kwargs
-        self.use_sparse_z = use_sparse_z
         self.unbiased_z_hat = unbiased_z_hat
 
         # D-step parameters
@@ -201,11 +203,11 @@ class ConvolutionalDictionaryLearning(TransformerMixin):
             solver_z=self.solver_z, solver_z_kwargs=self.solver_z_kwargs,
             solver_d=self.solver_d, solver_d_kwargs=self.solver_d_kwargs,
             D_init=self.D_init, D_init_params=self.D_init_params,
-            use_sparse_z=self.use_sparse_z, unbiased_z_hat=False,
-            verbose=self.verbose, callback=self.callback,
+            unbiased_z_hat=False, verbose=self.verbose, callback=self.callback,
             random_state=self.random_state, n_jobs=self.n_jobs,
             name=self.name, raise_on_increase=self.raise_on_increase,
-            sort_atoms=self.sort_atoms)
+            sort_atoms=self.sort_atoms
+        )
 
         self._pobj, self._times, self._D_hat, self._z_hat, self.reg_ = res
         self.n_channels_ = X.shape[1]
@@ -353,8 +355,9 @@ class BatchCDL(ConvolutionalDictionaryLearning):
             solver_d=solver_d, solver_d_kwargs=solver_d_kwargs,
             eps=eps, D_init=D_init, D_init_params=D_init_params,
             algorithm='batch', lmbd_max=lmbd_max, raise_on_increase=True,
-            loss='l2', use_sparse_z=False, n_jobs=n_jobs, verbose=verbose,
-            callback=None, random_state=random_state, name="BatchCDL")
+            loss='l2', n_jobs=n_jobs, verbose=verbose, callback=None,
+            random_state=random_state, name="BatchCDL"
+        )
 
 
 class GreedyCDL(ConvolutionalDictionaryLearning):
@@ -379,5 +382,6 @@ class GreedyCDL(ConvolutionalDictionaryLearning):
             solver_d=solver_d, solver_d_kwargs=solver_d_kwargs,
             eps=eps, D_init=D_init, D_init_params=D_init_params,
             algorithm='greedy', lmbd_max=lmbd_max, raise_on_increase=True,
-            loss='l2', use_sparse_z=False, n_jobs=n_jobs, verbose=verbose,
-            callback=None, random_state=random_state, name="GreedyCDL")
+            loss='l2', n_jobs=n_jobs, verbose=verbose, callback=None,
+            random_state=random_state, name="GreedyCDL"
+        )

--- a/alphacsc/cython_code/__init__.py
+++ b/alphacsc/cython_code/__init__.py
@@ -1,17 +1,16 @@
 
 try:
+    from .compute_ztX import _fast_compute_ztX
+    from .compute_ztz import _fast_compute_ztz
+    from .compute_ztz import _fast_compute_ztz_csr
     from .sparse_conv import _fast_sparse_convolve_multi
     from .sparse_conv import _fast_sparse_convolve_multi_uv
-    from .compute_ztz import _fast_compute_ztz
-    from .compute_ztz import _fast_compute_ztz_lil, _fast_compute_ztz_csr
-    from .compute_ztX import _fast_compute_ztX
     from .coordinate_descent import subtract_zhat_to_beta, update_dz_opt
     _CYTHON_AVAILABLE = True
 
     __all__ = ["_fast_sparse_convolve_multi", "_fast_sparse_convolve_multi_uv",
-               "_fast_compute_ztz", "_fast_compute_ztz_lil",
-               "_fast_compute_ztz_csr", "_fast_compute_ztX",
-               "subtract_zhat_to_beta", "update_dz_opt"]
+               "_fast_compute_ztz", "_fast_compute_ztz_csr",
+               "_fast_compute_ztX", "subtract_zhat_to_beta", "update_dz_opt"]
 
 except ImportError:  # pragma: no cover
     _CYTHON_AVAILABLE = False

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -68,7 +68,7 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
         If set to True, learn rank 1 dictionary atoms.
         If solver_z is 'dicodile', then rank1 must be False.
     uv_constraint : str in {'joint' | 'separate' | 'auto'}
-        The kind of norm constraint on the atoms if using rank=True.
+        The kind of norm constraint on the atoms if using rank1=True.
         If 'joint', the constraint is norm_2([u, v]) <= 1
         If 'separate', the constraint is norm_2(u) <= 1 and norm_2(v) <= 1
         If rank1 is False, then uv_constraint must be 'auto'.
@@ -121,7 +121,7 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
         The verbosity level.
     callback : func
         A callback function called at the end of each loop of the
-        coordinate descent, with z_encoder and pob as its arguments.
+        coordinate descent, with z_encoder and pobj as its arguments.
     random_state : int | None
         The random state.
     raise_on_increase : boolean

--- a/alphacsc/online_dictionary_learning.py
+++ b/alphacsc/online_dictionary_learning.py
@@ -37,11 +37,10 @@ class OnlineCDL(ConvolutionalDictionaryLearning):
 
     def __init__(self, n_atoms, n_times_atom, reg=0.1, n_iter=60, n_jobs=1,
                  solver_z='lgcd', solver_z_kwargs={}, unbiased_z_hat=False,
-                 solver_d='alternate_adaptive', solver_d_kwargs={},
-                 rank1=True, window=False, uv_constraint='separate',
-                 lmbd_max='scaled', eps=1e-10, D_init=None, D_init_params={},
-                 alpha=.8, batch_size=1, batch_selection='random',
-                 verbose=10, random_state=None):
+                 solver_d='auto', solver_d_kwargs={}, rank1=True, window=False,
+                 uv_constraint='auto', lmbd_max='scaled', eps=1e-10,
+                 D_init=None, D_init_params={}, alpha=.8, batch_size=1,
+                 batch_selection='random', verbose=10, random_state=None):
         super().__init__(
             n_atoms, n_times_atom, reg=reg, n_iter=n_iter,
             solver_z=solver_z, solver_z_kwargs=solver_z_kwargs,
@@ -53,8 +52,8 @@ class OnlineCDL(ConvolutionalDictionaryLearning):
                                   batch_selection=batch_selection),
             n_jobs=n_jobs, random_state=random_state, algorithm='online',
             lmbd_max=lmbd_max, raise_on_increase=False, loss='l2',
-            callback=None, use_sparse_z=False, verbose=verbose,
-            name="OnlineCDL")
+            callback=None, verbose=verbose, name="OnlineCDL"
+        )
 
     def partial_fit(self, X, y=None):
         # Successive partial_fit are equivalent to OnlineCDL only if
@@ -99,13 +98,14 @@ class OnlineCDL(ConvolutionalDictionaryLearning):
                 X, z_hat, uv_hat0=self._D_hat, constants=self.constants,
                 solver_d=self.solver_d, uv_constraint=self.uv_constraint,
                 loss=self.loss, loss_params=self.loss_params,
-                window=self.window, **d_kwargs)
+                window=self.window, **d_kwargs
+            )
         else:
             self._D_hat = update_d(
                 X, z_hat, D_hat0=self._D_hat, constants=self.constants,
-                solver_d=self.solver_d, uv_constraint=self.uv_constraint,
-                loss=self.loss, loss_params=self.loss_params,
-                window=self.window, **d_kwargs)
+                solver_d=self.solver_d, window=self.window,
+                loss=self.loss, loss_params=self.loss_params, **d_kwargs
+            )
 
         return z_hat
 

--- a/alphacsc/tests/conftest.py
+++ b/alphacsc/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+parametrize_solver_and_constraint = pytest.mark.parametrize(
+    'rank1, solver_d, uv_constraint',
+    [
+        (True, 'auto', 'auto'),
+        (False, 'auto', 'auto'),
+        (False, 'fista', 'auto'),
+        (True, 'joint', 'joint'),
+        (True, 'joint', 'separate'),
+        (True, 'alternate_adaptive', 'separate')
+    ]
+)

--- a/alphacsc/tests/test_encoder.py
+++ b/alphacsc/tests/test_encoder.py
@@ -38,23 +38,20 @@ def requires_dicodile(solver):
 
 
 @pytest.mark.parametrize('solver', ['l-bfgs', 'lgcd'])
-@pytest.mark.parametrize('algorithm', ['batch', 'greedy', 'online',
-                                       'stochastic'])
 @pytest.mark.parametrize('loss', ['l2', 'dtw', 'whitening'])
 @pytest.mark.parametrize('uv_constraint', ['joint', 'separate', 'auto'])
 @pytest.mark.parametrize('feasible_evaluation', [True, False])
 @pytest.mark.parametrize('n_trials', [1, 2, 5])
 @pytest.mark.parametrize('rank1', [True, False])
-def test_get_encoder_for_alphacsc(X, solver, D_hat, algorithm, loss,
-                                  uv_constraint, feasible_evaluation):
+def test_get_encoder_for_alphacsc(X, solver, D_hat, loss, uv_constraint,
+                                  feasible_evaluation):
     """Test for valid values for alphacsc backend."""
 
     with get_z_encoder_for(solver=solver,
                            X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
-                           atom_support=N_TIMES_ATOM,
-                           algorithm=algorithm,
+                           n_times_atom=N_TIMES_ATOM,
                            loss=loss,
                            uv_constraint=uv_constraint,
                            feasible_evaluation=feasible_evaluation,
@@ -71,7 +68,7 @@ def test_get_encoder_for_dicodile(X, D_hat, solver, requires_dicodile):
                            X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
-                           atom_support=N_TIMES_ATOM,
+                           n_times_atom=N_TIMES_ATOM,
                            n_jobs=2) as z_encoder:
 
         assert z_encoder is not None
@@ -88,7 +85,7 @@ def test_get_encoder_for_dicodile_error_n_trials(solver, X, D_hat,
                           X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -105,7 +102,7 @@ def test_get_encoder_for_dicodile_error_loss(solver, X, D_hat, loss,
                           D_hat=D_hat,
                           loss=loss,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -121,7 +118,7 @@ def test_get_encoder_for_dicodile_error_loss_params(solver, X, D_hat,
                           D_hat=D_hat,
                           loss_params={},
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -137,7 +134,7 @@ def test_get_encoder_for_dicodile_error_feasible_ev(solver, X, D_hat,
                           D_hat=D_hat,
                           feasible_evaluation=True,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -153,23 +150,7 @@ def test_get_encoder_for_dicodile_error_uv_constraint(solver, X, D_hat,
                           D_hat=D_hat,
                           uv_constraint='separate',
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
-                          n_jobs=2)
-
-
-@pytest.mark.parametrize('solver, n_trials, rank1', [('dicodile', 1, False)])
-def test_get_encoder_for_dicodile_error_use_sparse_z(solver, X, D_hat,
-                                                     requires_dicodile):
-    """Test for invalid use_sparse_z value for dicodile backend."""
-
-    with pytest.raises(AssertionError,
-                       match="DiCoDiLe requires use_sparse_z=False."):
-        get_z_encoder_for(solver=solver,
-                          X=X,
-                          D_hat=D_hat,
-                          use_sparse_z=True,
-                          n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -182,7 +163,7 @@ def test_get_encoder_for_dicodile_error_rank1(X, D_hat, requires_dicodile):
                           X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -198,7 +179,7 @@ def test_get_encoder_for_error_solver(X, D_hat,  solver):
                           X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -212,7 +193,7 @@ def test_get_encoder_for_error_solver_kwargs(X, D_hat):
                           X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -227,7 +208,7 @@ def test_get_encoder_for_error_X(X_error, D_hat):
         get_z_encoder_for(X=X_error,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -241,23 +222,7 @@ def test_get_encoder_for_error_D_hat(X, D_init):
         get_z_encoder_for(X=X,
                           D_hat=D_init,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
-                          n_jobs=2)
-
-
-@pytest.mark.parametrize('n_trials', [2])
-@pytest.mark.parametrize('rank1', [True])
-@pytest.mark.parametrize('algorithm', [None, 'other'])
-def test_get_encoder_for_error_algorithm(X, D_hat,  algorithm):
-    """Tests for invalid values of `algorithm`."""
-
-    with pytest.raises(AssertionError,
-                       match=f"unrecognized algorithm type: {algorithm}"):
-        get_z_encoder_for(X=X,
-                          D_hat=D_hat,
-                          n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
-                          algorithm=algorithm,
+                          n_times_atom=N_TIMES_ATOM,
                           n_jobs=2)
 
 
@@ -271,7 +236,7 @@ def test_get_encoder_for_error_reg(X, D_hat):
         get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           reg=None,
                           n_jobs=2)
 
@@ -287,7 +252,7 @@ def test_get_encoder_for_error_loss(X, D_hat,  loss):
         get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           loss=loss,
                           n_jobs=2)
 
@@ -302,7 +267,7 @@ def test_get_encoder_for_error_loss_params(X, D_hat):
         get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           loss_params=42,
                           n_jobs=2)
 
@@ -319,7 +284,7 @@ def test_get_encoder_for_error_uv_constraint(X, D_hat,
         get_z_encoder_for(X=X,
                           D_hat=D_hat,
                           n_atoms=N_ATOMS,
-                          atom_support=N_TIMES_ATOM,
+                          n_times_atom=N_TIMES_ATOM,
                           uv_constraint=uv_constraint,
                           n_jobs=2)
 
@@ -335,37 +300,14 @@ def test_get_z_hat(solver, X, D_hat, requires_dicodile):
                            X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
-                           atom_support=N_TIMES_ATOM,
-                           n_jobs=2,
-                           use_sparse_z=False) as z_encoder:
+                           n_times_atom=N_TIMES_ATOM,
+                           n_jobs=2) as z_encoder:
 
         assert z_encoder is not None
         assert not z_encoder.get_z_hat().any()
 
         z_encoder.compute_z()
         assert z_encoder.get_z_hat().any()
-
-
-@pytest.mark.parametrize('n_trials', [1, 3])
-@pytest.mark.parametrize('rank1', [True, False])
-def test_get_z_hat_use_sparse_z(X, D_hat):
-    """Test for valid values when use_sparse_z=True."""
-    with get_z_encoder_for(solver='lgcd',
-                           X=X,
-                           D_hat=D_hat,
-                           n_atoms=N_ATOMS,
-                           atom_support=N_TIMES_ATOM,
-                           n_jobs=2,
-                           use_sparse_z=True) as z_encoder:
-
-        assert z_encoder is not None
-
-        for matrix in z_encoder.get_z_hat():
-            assert not matrix.count_nonzero()
-
-        z_encoder.compute_z()
-        for matrix in z_encoder.get_z_hat():
-            assert matrix.count_nonzero()
 
 
 @pytest.mark.parametrize('solver, n_trials, rank1', [('l-bfgs', 3, True),
@@ -377,7 +319,7 @@ def test_get_cost(solver, X, D_hat, requires_dicodile):
                            X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
-                           atom_support=N_TIMES_ATOM,
+                           n_times_atom=N_TIMES_ATOM,
                            n_jobs=2) as z_encoder:
         initial_cost = z_encoder.get_cost()
 
@@ -404,7 +346,7 @@ def test_compute_z(solver, X, D_hat, requires_dicodile):
                            X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
-                           atom_support=N_TIMES_ATOM,
+                           n_times_atom=N_TIMES_ATOM,
                            n_jobs=2) as z_encoder:
         z_encoder.compute_z()
         assert z_encoder.get_z_hat().any()
@@ -418,7 +360,7 @@ def test_compute_z_partial(X, D_hat, n_trials, rng):
     with get_z_encoder_for(X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
-                           atom_support=N_TIMES_ATOM,
+                           n_times_atom=N_TIMES_ATOM,
                            n_jobs=2) as z_encoder:
 
         i0 = rng.choice(n_trials, 1, replace=False)
@@ -436,7 +378,7 @@ def test_get_sufficient_statistics(solver, X, D_hat, requires_dicodile):
                                   X=X,
                                   D_hat=D_hat,
                                   n_atoms=N_ATOMS,
-                                  atom_support=N_TIMES_ATOM,
+                                  n_times_atom=N_TIMES_ATOM,
                                   n_jobs=2)
 
     z_encoder.compute_z()
@@ -461,7 +403,7 @@ def test_get_sufficient_statistics_error(solver, X, D_hat,
                                   X=X,
                                   D_hat=D_hat,
                                   n_atoms=N_ATOMS,
-                                  atom_support=N_TIMES_ATOM,
+                                  n_times_atom=N_TIMES_ATOM,
                                   n_jobs=2)
 
     # test before calling compute_z
@@ -478,7 +420,7 @@ def test_get_sufficient_statistics_partial(X, D_hat, n_trials, rng):
     z_encoder = get_z_encoder_for(X=X,
                                   D_hat=D_hat,
                                   n_atoms=N_ATOMS,
-                                  atom_support=N_TIMES_ATOM,
+                                  n_times_atom=N_TIMES_ATOM,
                                   n_jobs=2)
 
     i0 = rng.choice(n_trials, 1, replace=False)
@@ -496,7 +438,7 @@ def test_get_sufficient_statistics_partial_error(X, D_hat):
     z_encoder = get_z_encoder_for(X=X,
                                   D_hat=D_hat,
                                   n_atoms=N_ATOMS,
-                                  atom_support=N_TIMES_ATOM,
+                                  n_times_atom=N_TIMES_ATOM,
                                   n_jobs=2)
 
     # test before calling compute_z_partial
@@ -513,7 +455,7 @@ def test_add_one_atom(X, D_hat):
     with get_z_encoder_for(X=X,
                            D_hat=D_hat,
                            n_atoms=N_ATOMS,
-                           atom_support=N_TIMES_ATOM,
+                           n_times_atom=N_TIMES_ATOM,
                            n_jobs=2) as z_encoder:
         new_atom = np.random.rand(N_CHANNELS + N_TIMES_ATOM)
         z_encoder.add_one_atom(new_atom)

--- a/alphacsc/tests/test_init_d.py
+++ b/alphacsc/tests/test_init_d.py
@@ -6,19 +6,32 @@ from numpy.testing import assert_allclose
 
 from alphacsc.init_dict import init_dictionary
 from alphacsc.update_d_multi import prox_uv, prox_d
+from alphacsc.update_d_multi import check_solver_and_constraints
 from alphacsc.learn_d_z_multi import learn_d_z_multi
 from alphacsc.utils import check_random_state
 
 
-@pytest.mark.parametrize("rank1", [True, False])
-@pytest.mark.parametrize("uv_constraint", ['separate', 'joint'])
-def test_init_array(rank1, uv_constraint):
+@pytest.mark.parametrize(
+    'rank1, solver_d, uv_constraint',
+    [
+        (True, 'auto', 'auto'),
+        (False, 'auto', 'auto'),
+        (False, 'fista', 'auto'),
+        (True, 'joint', 'joint'),
+        (True, 'joint', 'separate'),
+        (True, 'alternate_adaptive', 'separate')
+    ])
+def test_init_array(rank1, solver_d, uv_constraint):
     n_trials, n_channels, n_times = 5, 3, 100
     n_times_atom, n_atoms = 10, 4
 
+    _, uv_constraint_ = check_solver_and_constraints(
+        rank1, solver_d, uv_constraint
+    )
+
     if rank1:
         expected_shape = (n_atoms, n_channels + n_times_atom)
-        prox = functools.partial(prox_uv, uv_constraint=uv_constraint,
+        prox = functools.partial(prox_uv, uv_constraint=uv_constraint_,
                                  n_channels=n_channels)
     else:
         expected_shape = (n_atoms, n_channels, n_times_atom)
@@ -29,7 +42,7 @@ def test_init_array(rank1, uv_constraint):
     # Test that init_dictionary is doing what we expect for D_init array
     D_init = np.random.randn(*expected_shape)
     D_hat = init_dictionary(X, n_atoms, n_times_atom, D_init=D_init,
-                            rank1=rank1, uv_constraint=uv_constraint)
+                            rank1=rank1, uv_constraint=uv_constraint_)
 
     D_init = prox(D_init)
     assert_allclose(D_hat, D_init)
@@ -38,23 +51,36 @@ def test_init_array(rank1, uv_constraint):
     # Test that learn_d_z_multi is doing what we expect for D_init array
     D_init = np.random.randn(*expected_shape)
     _, _, D_hat, _, _ = learn_d_z_multi(
-        X, n_atoms, n_times_atom, D_init=D_init, n_iter=0, rank1=rank1,
-        uv_constraint=uv_constraint)
+        X, n_atoms, n_times_atom, D_init=D_init, n_iter=0,
+        rank1=rank1, solver_d=solver_d, uv_constraint=uv_constraint
+    )
 
     D_init = prox(D_init)
     assert_allclose(D_hat, D_init)
 
 
-@pytest.mark.parametrize("rank1", [True, False])
-@pytest.mark.parametrize("uv_constraint", ['separate', 'joint'])
-def test_init_random(rank1, uv_constraint):
+@pytest.mark.parametrize(
+    'rank1, solver_d, uv_constraint',
+    [
+        (True, 'auto', 'auto'),
+        (False, 'auto', 'auto'),
+        (False, 'fista', 'auto'),
+        (True, 'joint', 'joint'),
+        (True, 'joint', 'separate'),
+        (True, 'alternate_adaptive', 'separate')
+    ])
+def test_init_random(rank1, solver_d, uv_constraint):
     """"""
     n_trials, n_channels, n_times = 5, 3, 100
     n_times_atom, n_atoms = 10, 4
 
+    _, uv_constraint_ = check_solver_and_constraints(
+        rank1, solver_d, uv_constraint
+    )
+
     if rank1:
         expected_shape = (n_atoms, n_channels + n_times_atom)
-        prox = functools.partial(prox_uv, uv_constraint=uv_constraint,
+        prox = functools.partial(prox_uv, uv_constraint=uv_constraint_,
                                  n_channels=n_channels)
     else:
         expected_shape = (n_atoms, n_channels, n_times_atom)
@@ -65,7 +91,7 @@ def test_init_random(rank1, uv_constraint):
     # Test that init_dictionary is doing what we expect for D_init random
     random_state = 42
     D_hat = init_dictionary(X, n_atoms, n_times_atom, D_init='random',
-                            rank1=rank1, uv_constraint=uv_constraint,
+                            rank1=rank1, uv_constraint=uv_constraint_,
                             random_state=random_state)
     rng = check_random_state(random_state)
 
@@ -78,7 +104,9 @@ def test_init_random(rank1, uv_constraint):
     random_state = 27
     _, _, D_hat, _, _ = learn_d_z_multi(
         X, n_atoms, n_times_atom, D_init='random', n_iter=0,
-        rank1=rank1, uv_constraint=uv_constraint, random_state=random_state)
+        rank1=rank1, solver_d=solver_d, uv_constraint=uv_constraint,
+        random_state=random_state
+    )
 
     rng = check_random_state(random_state)
     D_init = rng.randn(*expected_shape)

--- a/alphacsc/tests/test_init_d.py
+++ b/alphacsc/tests/test_init_d.py
@@ -10,17 +10,10 @@ from alphacsc.update_d_multi import check_solver_and_constraints
 from alphacsc.learn_d_z_multi import learn_d_z_multi
 from alphacsc.utils import check_random_state
 
+from alphacsc.tests.conftest import parametrize_solver_and_constraint
 
-@pytest.mark.parametrize(
-    'rank1, solver_d, uv_constraint',
-    [
-        (True, 'auto', 'auto'),
-        (False, 'auto', 'auto'),
-        (False, 'fista', 'auto'),
-        (True, 'joint', 'joint'),
-        (True, 'joint', 'separate'),
-        (True, 'alternate_adaptive', 'separate')
-    ])
+
+@parametrize_solver_and_constraint
 def test_init_array(rank1, solver_d, uv_constraint):
     n_trials, n_channels, n_times = 5, 3, 100
     n_times_atom, n_atoms = 10, 4
@@ -59,16 +52,7 @@ def test_init_array(rank1, solver_d, uv_constraint):
     assert_allclose(D_hat, D_init)
 
 
-@pytest.mark.parametrize(
-    'rank1, solver_d, uv_constraint',
-    [
-        (True, 'auto', 'auto'),
-        (False, 'auto', 'auto'),
-        (False, 'fista', 'auto'),
-        (True, 'joint', 'joint'),
-        (True, 'joint', 'separate'),
-        (True, 'alternate_adaptive', 'separate')
-    ])
+@parametrize_solver_and_constraint
 def test_init_random(rank1, solver_d, uv_constraint):
     """"""
     n_trials, n_channels, n_times = 5, 3, 100

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -8,19 +8,12 @@ from alphacsc.convolutional_dictionary_learning import BatchCDL, GreedyCDL
 from alphacsc.online_dictionary_learning import OnlineCDL
 from alphacsc.init_dict import init_dictionary
 
+from alphacsc.tests.conftest import parametrize_solver_and_constraint
+
 
 @pytest.mark.parametrize('window', [False, True])
 @pytest.mark.parametrize('loss', ['l2', 'dtw', 'whitening'])
-@pytest.mark.parametrize(
-    'rank1, solver_d, uv_constraint',
-    [
-        (True, 'auto', 'auto'),
-        (False, 'auto', 'auto'),
-        (False, 'fista', 'auto'),
-        (True, 'joint', 'joint'),
-        (True, 'joint', 'separate'),
-        (True, 'alternate_adaptive', 'separate')
-    ])
+@parametrize_solver_and_constraint
 def test_learn_d_z_multi(loss, rank1, solver_d, uv_constraint, window):
     # smoke test for learn_d_z_multi
     n_trials, n_channels, n_times = 2, 3, 30
@@ -78,16 +71,7 @@ def test_learn_d_z_multi_dicodile(window):
         raise
 
 
-@pytest.mark.parametrize(
-    'rank1, solver_d, uv_constraint',
-    [
-        (True, 'auto', 'auto'),
-        (False, 'auto', 'auto'),
-        (False, 'fista', 'auto'),
-        (True, 'joint', 'joint'),
-        (True, 'joint', 'separate'),
-        (True, 'alternate_adaptive', 'separate')
-    ])
+@parametrize_solver_and_constraint
 def test_window(rank1, solver_d, uv_constraint):
     # Smoke test that the parameter window does something
     n_trials, n_channels, n_times = 2, 3, 100

--- a/alphacsc/update_d_multi.py
+++ b/alphacsc/update_d_multi.py
@@ -37,7 +37,8 @@ def check_solver_and_constraints(rank1, solver_d, uv_constraint):
     else:
         assert solver_d in ['auto', 'fista'] and uv_constraint == 'auto', (
             "If rank1 is False, uv_constraint should be 'auto' "
-            f"and solver_d should be auto or fista. Got {uv_constraint}"
+            "and solver_d should be auto or fista. "
+            f"Got {solver_d=} and {uv_constraint=}."
         )
         solver_d = 'fista'
     return solver_d, uv_constraint

--- a/alphacsc/update_d_multi.py
+++ b/alphacsc/update_d_multi.py
@@ -3,11 +3,8 @@
 #          Umut Simsekli <umut.simsekli@telecom-paristech.fr>
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Thomas Moreau <thomas.moreau@inria.fr>
-
 import numpy as np
 
-from . import cython_code
-from .utils.lil import get_z_shape, is_list_of_lil
 from .utils.optim import fista, power_iteration
 from .utils.convolution import numpy_convolve_uv
 from .utils.compute_constants import compute_ztz, compute_ztX
@@ -20,6 +17,30 @@ from .loss_and_gradient import gradient_uv, gradient_d
 def squeeze_all_except_one(X, axis=0):
     squeeze_axis = tuple(set(range(X.ndim)) - set([axis]))
     return X.squeeze(axis=squeeze_axis)
+
+
+def check_solver_and_constraints(rank1, solver_d, uv_constraint):
+
+    if rank1:
+        if solver_d == 'auto':
+            solver_d = 'alternate_adaptive'
+        if 'alternate' in solver_d:
+            if uv_constraint == 'auto':
+                uv_constraint = 'separate'
+            else:
+                assert uv_constraint == 'separate', (
+                    "solver_d='alternate*' should be used with "
+                    f"uv_constraint='separate'. Got '{uv_constraint}'."
+                )
+        elif uv_constraint == 'auto' and solver_d in ['joint', 'fista']:
+            uv_constraint = 'joint'
+    else:
+        assert solver_d in ['auto', 'fista'] and uv_constraint == 'auto', (
+            "If rank1 is False, uv_constraint should be 'auto' "
+            f"and solver_d should be auto or fista. Got {uv_constraint}"
+        )
+        solver_d = 'fista'
+    return solver_d, uv_constraint
 
 
 def prox_uv(uv, uv_constraint='joint', n_channels=None, return_norm=False):
@@ -103,7 +124,7 @@ def update_uv(X, z, uv_hat0, constants=None, b_hat_0=None, debug=False,
     uv_hat : array, shape (n_atoms, n_channels + n_times_atom)
         The atoms to learn from the data.
     """
-    n_trials, n_atoms, n_times_valid = get_z_shape(z)
+    n_trials, n_atoms, n_times_valid = z.shape
     _, n_channels, n_times = X.shape
     n_times_atom = uv_hat0.shape[1] - n_channels
 
@@ -111,10 +132,6 @@ def update_uv(X, z, uv_hat0, constants=None, b_hat_0=None, debug=False,
         tukey_window_ = tukey_window(n_times_atom)[None, :]
         uv_hat0 = uv_hat0.copy()
         uv_hat0[:, n_channels:] /= tukey_window_
-
-    if solver_d == 'alternate':
-        msg = "alternate solver should be used with separate constraints"
-        assert uv_constraint == 'separate', msg
 
     if loss == 'l2' and constants is None:
         constants = _get_d_update_constants(X, z)
@@ -130,7 +147,7 @@ def update_uv(X, z, uv_hat0, constants=None, b_hat_0=None, debug=False,
                                              feasible_evaluation=True,
                                              uv_constraint=uv_constraint)
 
-    if solver_d in ['joint', 'fista']:
+    if solver_d in ['fista', 'joint']:
         # use FISTA on joint [u, v], with an adaptive step size
 
         def grad(uv):
@@ -253,8 +270,7 @@ def update_uv(X, z, uv_hat0, constants=None, b_hat_0=None, debug=False,
 
 def update_d(X, z, D_hat0, constants=None, b_hat_0=None, debug=False,
              max_iter=300, eps=None, solver_d='fista', momentum=False,
-             uv_constraint='joint', loss='l2', loss_params=dict(), verbose=0,
-             window=False):
+             loss='l2', loss_params=dict(), verbose=0, window=False):
     """Learn d's in time domain.
 
     Parameters
@@ -293,9 +309,7 @@ def update_d(X, z, D_hat0, constants=None, b_hat_0=None, debug=False,
     D_hat : array, shape (n_atoms, n_channels, n_times_atom)
         The atoms to learn from the data.
     """
-    n_trials, n_atoms, n_times_valid = get_z_shape(z)
-    _, n_channels, n_times = X.shape
-    n_atoms, n_channels, n_times_atom = D_hat0.shape
+    *_, n_times_atom = D_hat0.shape
 
     if window:
         tukey_window_ = tukey_window(n_times_atom)[None, None, :]
@@ -312,8 +326,8 @@ def update_d(X, z, D_hat0, constants=None, b_hat_0=None, debug=False,
         return compute_X_and_objective_multi(X, z, D_hat=D, loss=loss,
                                              loss_params=loss_params)
 
-    if True:  # only solver available here
-        # use FISTA on joint [u, v], with an adaptive step size
+    if solver_d in ['fista', 'auto']:  # only solver available here
+        # use FISTA on D, with an adaptive step size
 
         def grad(D):
             if window:
@@ -349,17 +363,12 @@ def update_d(X, z, D_hat0, constants=None, b_hat_0=None, debug=False,
 
 
 def _get_d_update_constants(X, z):
-    n_trials, n_atoms, n_times_valid = get_z_shape(z)
+    n_trials, n_atoms, n_times_valid = z.shape
     n_trials, n_channels, n_times = X.shape
     n_times_atom = n_times - n_times_valid + 1
 
-    if is_list_of_lil(z):
-        cython_code._assert_cython()
-        ztX = cython_code._fast_compute_ztX(z, X)
-        ztz = cython_code._fast_compute_ztz(z, n_times_atom)
-    else:
-        ztX = compute_ztX(z, X)
-        ztz = compute_ztz(z, n_times_atom)
+    ztX = compute_ztX(z, X)
+    ztz = compute_ztz(z, n_times_atom)
 
     constants = {}
     constants['ztX'] = ztX
@@ -401,4 +410,6 @@ def compute_lipschitz(uv0, constants, variable, b_hat_0=None,
         b_hat_v0 = b_hat_0.reshape(n_atoms, -1)[:, n_channels:].ravel()
         n_points = n_atoms * n_times_atom
         L = power_iteration(op_Hv, n_points, b_hat_0=b_hat_v0)
+    else:
+        raise ValueError("variable should be either 'u' or 'v'")
     return L

--- a/alphacsc/update_d_multi.py
+++ b/alphacsc/update_d_multi.py
@@ -37,8 +37,8 @@ def check_solver_and_constraints(rank1, solver_d, uv_constraint):
     else:
         assert solver_d in ['auto', 'fista'] and uv_constraint == 'auto', (
             "If rank1 is False, uv_constraint should be 'auto' "
-            "and solver_d should be auto or fista. "
-            f"Got {solver_d=} and {uv_constraint=}."
+            f"and solver_d should be auto or fista. Got solver_d='{solver_d}' "
+            f"and uv_constraint='{uv_constraint}'."
         )
         solver_d = 'fista'
     return solver_d, uv_constraint

--- a/alphacsc/utils/dictionary.py
+++ b/alphacsc/utils/dictionary.py
@@ -38,13 +38,25 @@ def get_uv(D):
     return uv
 
 
-def _patch_reconstruction_error(X, z, D):
-    """Return the reconstruction error for each patches of size (P, L)."""
-    n_trials, n_channels, n_times = X.shape
+def get_D_shape(D, n_channels):
     if D.ndim == 2:
         n_times_atom = D.shape[1] - n_channels
     else:
+        if n_channels is None:
+            n_channels = D.shape[1]
+        else:
+            assert n_channels == D.shape[1], (
+                f"n_channels does not match D.shape: {D.shape}"
+            )
         n_times_atom = D.shape[2]
+
+    return (D.shape[0], n_channels, n_times_atom)
+
+
+def _patch_reconstruction_error(X, z, D):
+    """Return the reconstruction error for each patches of size (P, L)."""
+    _, n_channels, _ = X.shape
+    *_, n_times_atom = get_D_shape(D, n_channels)
 
     from .convolution import construct_X_multi
     X_hat = construct_X_multi(z, D, n_channels=n_channels)

--- a/benchmarks/1D_vs_multi_run.py
+++ b/benchmarks/1D_vs_multi_run.py
@@ -122,7 +122,7 @@ def run_one(reg, sigma, n_atoms, n_times_atom, max_n_channels, n_times_valid,
 
     pobj, times, uv_hat, z_hat, reg = learn_d_z_multi(
         X[:, :run_n_channels, :], n_atoms, n_times_atom,
-        random_state=random_state,
+        random_state=random_state, rank1=True,
         # callback=cb,
         n_iter=n_iter, n_jobs=1, reg=reg_, uv_constraint='separate',
         solver_d='alternate_adaptive', solver_d_kwargs={'max_iter': 50},

--- a/benchmarks/1D_vs_multi_run.py
+++ b/benchmarks/1D_vs_multi_run.py
@@ -112,9 +112,10 @@ def run_one(reg, sigma, n_atoms, n_times_atom, max_n_channels, n_times_valid,
     uv_ = prox_uv(np.c_[uv[:, :run_n_channels], uv[:, max_n_channels:]],
                   uv_constraint='separate', n_channels=max_n_channels)
 
-    def cb(X, uv_hat, z_hat, pobj):
+    def cb(z_encoder, pobj):
         it = len(pobj) // 2
         if it % 10 == 0:
+            uv_hat = z_encoder.D_hat
             print("[channels{}] iter{} score sig={:.2e}: {:.3e}".format(
                 run_n_channels, it, sigma,
                 score_uv(uv_, uv_hat, run_n_channels)))
@@ -126,7 +127,7 @@ def run_one(reg, sigma, n_atoms, n_times_atom, max_n_channels, n_times_valid,
         n_iter=n_iter, n_jobs=1, reg=reg_, uv_constraint='separate',
         solver_d='alternate_adaptive', solver_d_kwargs={'max_iter': 50},
         solver_z="lgcd", solver_z_kwargs=dict(tol=1e-3, maxiter=500),
-        use_sparse_z=True, D_init=uv_init_, verbose=VERBOSE,
+        D_init=uv_init_, verbose=VERBOSE,
     )
 
     score = score_uv(uv_, uv_hat, run_n_channels)

--- a/benchmarks/scaling_channels_run.py
+++ b/benchmarks/scaling_channels_run.py
@@ -52,7 +52,7 @@ def run_multichannel(X, D_init, reg, n_iter, random_state,
         X, n_atoms, n_times_atom, reg=reg, n_iter=n_iter,
         uv_constraint='separate', rank1=True, D_init=D_init,
         solver_d='alternate_adaptive', solver_d_kwargs=dict(max_iter=50),
-        solver_z="lgcd", solver_z_kwargs=solver_z_kwargs, use_sparse_z=False,
+        solver_z="lgcd", solver_z_kwargs=solver_z_kwargs,
         name="rank1-{}-{}".format(n_channels, random_state),
         random_state=random_state, n_jobs=1, verbose=VERBOSE)
 
@@ -66,9 +66,9 @@ def run_multivariate(X, D_init, reg, n_iter, random_state,
     solver_z_kwargs = dict(max_iter=500, tol=1e-1)
     return learn_d_z_multi(
         X, n_atoms, n_times_atom, reg=reg, n_iter=n_iter,
-        uv_constraint='separate', rank1=False, D_init=D_init,
-        solver_d='l-bfgs', solver_d_kwargs=dict(max_iter=50),
-        solver_z="lgcd", solver_z_kwargs=solver_z_kwargs, use_sparse_z=False,
+        uv_constraint='auto', rank1=False, D_init=D_init,
+        solver_d='fista', solver_d_kwargs=dict(max_iter=50),
+        solver_z="lgcd", solver_z_kwargs=solver_z_kwargs,
         name="dense-{}-{}".format(n_channels, random_state),
         random_state=random_state, n_jobs=1, verbose=VERBOSE,
         raise_on_increase=False)

--- a/examples/dicodile/plot_gait.py
+++ b/examples/dicodile/plot_gait.py
@@ -3,7 +3,9 @@
 ====================
 Gait (steps) example
 ====================
-In this example, we use DiCoDiLe on an open dataset of gait (steps) IMU time-series to discover patterns in the data. We will then use those to attempt to detect steps and compare our findings with the ground truth.
+In this example, we use DiCoDiLe on an open dataset of gait (steps) IMU
+time-series to discover patterns in the data. We will then use those to attempt
+to detect steps and compare our findings with the ground truth.
 """
 
 import matplotlib.pyplot as plt
@@ -52,8 +54,8 @@ ax.legend()
 # # Convolutional Dictionary Learning
 
 ###############################################################################
-# Now, let’s use "dicodile" as solver_z to learn patterns from the data and reconstruct the
-# signal from a sparse representation.
+# Now, let’s use "dicodile" as solver_z to learn patterns from the data and
+# reconstruct the signal from a sparse representation.
 #
 # First, we initialize a dictionary from parts of the signal:
 
@@ -77,8 +79,8 @@ n_atoms = 8
 # set individual atom (patch) size.
 n_times_atom = 200
 
-D_init = init_dictionary(X, 
-                         n_atoms=8, 
+D_init = init_dictionary(X,
+                         n_atoms=8,
                          n_times_atom=200,
                          rank1=False,
                          window=True,
@@ -91,20 +93,20 @@ print(D_init.shape)
 from alphacsc import BatchCDL
 
 cdl = BatchCDL(
-     # Shape of the dictionary
-    n_atoms, 
-    n_times_atom, 
+    # Shape of the dictionary
+    n_atoms,
+    n_times_atom,
     rank1=False,
     uv_constraint='auto',
     # Number of iteration for the alternate minimization and cvg threshold
-    n_iter=3, 
+    n_iter=3,
     # number of workers to be used for dicodile
     n_jobs=4,
     # solver for the z-step
-    solver_z='dicodile', 
-    solver_z_kwargs={'max_iter': 10000}, 
+    solver_z='dicodile',
+    solver_z_kwargs={'max_iter': 10000},
     window=True,
-    D_init= D_init,
+    D_init=D_init,
     random_state=60)
 
 res = cdl.fit(X)
@@ -147,16 +149,20 @@ ax_hat.legend()
 np.count_nonzero(z_hat)
 
 ###############################################################################
-# Besides our visual check, a measure of how closely we’re reconstructing the original signal is the (normalized) cross-correlation. Let’s compute this:
+# Besides our visual check, a measure of how closely we’re reconstructing the
+# original signal is the (normalized) cross-correlation. Let’s compute this:
 
-np.correlate(X[0][0], X_hat[0][0]) / (
-    np.sqrt(np.correlate(X[0][0], X[0][0]) * np.correlate(X_hat[0][0], X_hat[0][0])))
+np.correlate(X[0][0], X_hat[0][0]) / np.sqrt(
+    np.correlate(X[0][0], X[0][0]) * np.correlate(X_hat[0][0], X_hat[0][0])
+)
 
 ###############################################################################
 # # Multichannel signals
 
 ###############################################################################
-# DiCoDiLe works just as well with multi-channel signals. The gait dataset contains 16 signals (8 for each foot), in the rest of this tutorial, we’ll use three of those.
+# DiCoDiLe works just as well with multi-channel signals. The gait dataset
+# contains 16 signals (8 for each foot), in the rest of this tutorial, we’ll
+# use three of those.
 
 # Left foot Vertical acceleration, Y rotation and X acceleration
 channels = ['LAV', 'LRY', 'LAX']
@@ -182,38 +188,37 @@ X_mc_subset = X_mc_subset.reshape(1, *X_mc_subset.shape)
 print(X_mc_subset.shape)
 
 ###############################################################################
-# Initialize the dictionary (note that the call is identical to the single-channel version)
+# Initialize the dictionary (note that the call is identical to the
+# single-channel version)
 
-D_init_mc = init_dictionary(X_mc_subset, 
-                         n_atoms=8, 
-                         n_times_atom=200,
-                         rank1=False,
-                         window=True,
-                         D_init='chunk',
-                         random_state=60)
+D_init_mc = init_dictionary(
+    X_mc_subset, n_atoms=8, n_times_atom=200, rank1=False,
+    window=True, D_init='chunk', random_state=60
+)
 
 print(D_init_mc.shape)
 
 ###############################################################################
-# And run DiCoDiLe (note that the call is identical to the single-channel version here as well)
+# And run DiCoDiLe (note that the call is identical to the single-channel
+# version here as well)
 
 from alphacsc import BatchCDL
 
 cdl = BatchCDL(
-     # Shape of the dictionary
-    n_atoms, 
-    n_times_atom, 
+    # Shape of the dictionary
+    n_atoms,
+    n_times_atom,
     rank1=False,
     uv_constraint='auto',
     # Number of iteration for the alternate minimization and cvg threshold
-    n_iter=3, 
+    n_iter=3,
     # number of workers to be used for dicodile
     n_jobs=4,
     # solver for the z-step
-    solver_z='dicodile', 
-    solver_z_kwargs={'max_iter': 10000}, 
+    solver_z='dicodile',
+    solver_z_kwargs={'max_iter': 10000},
     window=True,
-    D_init= D_init_mc,
+    D_init=D_init_mc,
     random_state=60)
 
 res = cdl.fit(X_mc_subset)
@@ -233,7 +238,8 @@ D_hat_mc = res._D_hat
 X_hat_mc = construct_X_multi(z_hat_mc, D_hat_mc)
 
 ###############################################################################
-# Let’s visually compare a small part of the original and reconstructed signals along with the activations.
+# Let’s visually compare a small part of the original and reconstructed signal
+# along with the activations.
 
 z_hat_mc.shape
 
@@ -262,4 +268,3 @@ for idx in range(z_hat_normalized.shape[1]):
     ax_hat_mc[1].stem(z_hat_normalized[0][idx][viz_start_idx:viz_end_idx],
                       linefmt=f"C{idx}-",
                       markerfmt=f"C{idx}o")
-


### PR DESCRIPTION
I did a pass on cleaning up some of the unused code that made the code more complex (in particular `use_sparse=True`).
I ended up changing a bunch a different stuff to make the code a cleaner:

- remove `use_sparse_z` and and simplify the code. Now, one should check that there is no leftover calls to `lil` matrices and remove the unused code?
- Remove `algorithm` from the encoder. Semantically, itshould not matter for the encoder.
- Add a `get_z_nnz` in the encoder to allow for reporting without accessing `z_hat`.
- Move `get_max_error_patch` in the encoder to also avoid accessing `z_hat` for greedy algorithm. This should be added in the `DicodileEncoder` and in `dicodile` as some point, we would need to have each worker compute its `max_error_patch` and return it with the error, and then only return the one with the max error.
- Add a `check_solver_and_constraints` to handle the `solver_d='auto'` and `uv_constraint='auto'` more reliably.
- Use `get_D_shape` everywhere to get the shape of `D` in rank-1` and non rank-1 cases.
- Change `atom_support` to `n_times_atom` in encoder API to be consistent with the `alphacsc` API.

This is mostly small changes a bit everywhere, if you could review this @hndgzkn and @rprimet, this would be nice!