### PR TITLE
ENH change dictionary initialization

### DIFF
--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .init_dict import get_dict_strategy
+from .init_dict import get_init_strategy
 from .loss_and_gradient import gradient_uv, gradient_d
 from .utils import check_random_state
 from .utils.convolution import numpy_convolve_uv
@@ -92,7 +92,7 @@ def get_solver_d(n_channels, n_atoms, n_times_atom,
         If 'joint', the constraint is norm_2([u, v]) <= 1
         If 'separate', the constraint is norm_2(u) <= 1 and norm_2(v) <= 1
         If rank1 is False, then uv_constraint must be 'auto'.
-    D_init : {'kmeans' | 'ssa' | 'chunk' | 'random'}
+    D_init : {'kmeans' | 'ssa' | 'chunk' | 'random' | 'greedy'}
              or array, shape (n_atoms, n_channels + n_times_atom) or
                          (n_atoms, n_channels, n_times_atom)
         The initialization scheme for the dictionary or the initial
@@ -164,7 +164,7 @@ class BaseDSolver:
         self.verbose = verbose
         self.debug = debug
 
-        self.dict_strategy = get_dict_strategy(
+        self.init_strategy = get_init_strategy(
             n_times_atom, self.get_D_shape(), self.rng, D_init, D_init_params
         )
 
@@ -238,8 +238,8 @@ class BaseDSolver:
     def init_dictionary(self, X):
         """Returns a dictionary for the signal X depending on D_init value.
 
-        Parameter
-        ---------
+        Parameters
+        ----------
         X: array, shape (n_trials, n_channels, n_times)
             The data on which to perform CSC.
 
@@ -250,9 +250,9 @@ class BaseDSolver:
             The initial atoms to learn from the data.
         """
 
-        D_hat = self.dict_strategy.initialize(X)
+        D_hat = self.init_strategy.initialize(X)
 
-        if not hasattr(self.dict_strategy, 'D_init'):
+        if not hasattr(self.init_strategy, 'D_init'):
             D_hat = self._windower.window(D_hat)
 
         self.D_hat = self.prox(D_hat)

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -239,7 +239,7 @@ class BaseDSolver:
             The initial atoms to learn from the data.
         """
 
-        self.D_hat = self.dictionary.init(X)
+        self.D_hat = self.dictionary.initialize(X)
 
         return self.D_hat
 

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -488,7 +488,7 @@ class AlternateDSolver(Rank1DSolver):
             return objective(uv)
 
         def op_Hv(v):
-            v = np.reshape(v, (self.D_hat.shape[0], z_encoder.n_times_atom))
+            v = np.reshape(v, (self.D_hat.shape[0], self.n_times_atom))
             uv = np.c_[u_hat, v]
             H_d = numpy_convolve_uv(z_encoder.ztz, uv)
             H_v = (H_d * uv[:, :n_channels, None]).sum(axis=1)

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -187,19 +187,19 @@ class BaseDSolver:
         return grad
 
     def window(self, D_hat):
-        return self.dict_generator.window(D_hat)
+        return self.dictionary.window(D_hat)
 
     def dewindow(self, D_hat):
-        return self.dict_generator.dewindow(D_hat)
+        return self.dictionary.dewindow(D_hat)
 
     def simple_window(self, D_hat):
-        return self.dict_generator.simple_window(D_hat)
+        return self.dictionary.simple_window(D_hat)
 
     def simple_dewindow(self, D_hat):
-        return self.dict_generator.simple_dewindow(D_hat)
+        return self.dictionary.simple_dewindow(D_hat)
 
     def prox(self, D):
-        return self.dict_generator.prox(D)
+        return self.dictionary.prox(D)
 
     def grad(self, D):
         raise NotImplementedError()
@@ -254,8 +254,8 @@ class BaseDSolver:
             The initial atoms to learn from the data.
         """
 
-        self.dict_generator.set_strategy(D_init)
-        D_hat = self.dict_generator.get_dict(X, D_init_params)
+        self.dictionary.set_init_strategy(D_init)
+        D_hat = self.dictionary.init(X, D_init_params)
 
         return D_hat
 
@@ -304,7 +304,7 @@ class Rank1DSolver(BaseDSolver):
             max_iter, momentum, random_state, verbose, debug
         )
 
-        self.dict_generator = Rank1Dictionary(
+        self.dictionary = Rank1Dictionary(
             self.n_channels, self.n_atoms, self.n_times_atom,
             self.rng, window, self.uv_constraint
         )
@@ -561,7 +561,7 @@ class DSolver(BaseDSolver):
             max_iter, momentum, random_state, verbose, debug
         )
 
-        self.dict_generator = Dictionary(
+        self.dictionary = Dictionary(
             self.n_channels, self.n_atoms, self.n_times_atom, self.rng, window
         )
 

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -262,18 +262,49 @@ class BaseDSolver:
         return self.D_hat
 
     def add_one_atom(self, z_encoder):
+        """Adds one atom to D_hat and updates D_hat in z_encoder.
+
+        Parameters
+        ----------
+        z_encoder: BaseZEncoder
+            ZEncoder object.
+
+        Returns
+        -------
+        D_hat : array, shape (n_atoms, n_channels + n_times_atom) or
+                             (n_atoms, n_channels, n_times_atom)
+            The atoms to learn from the data.
+        """
         new_atom = self.get_max_error_dict(z_encoder)[0]
 
         self.D_hat = np.concatenate([self.D_hat, new_atom[None]])
 
         z_encoder.set_D(self.D_hat)
+        return self.D_hat
 
     def resample_atom(self, k0, z_encoder):
+        """Resamples the atom at index k0 of D_hat and updates D_hat in
+        z_encoder.
+
+        Parameters
+        ----------
+        k0: int
+            index of the atom to resample
+        z_encoder: BaseZEncoder
+            ZEncoder object.
+
+        Returns
+        -------
+        D_hat : array, shape (n_atoms, n_channels + n_times_atom) or
+                             (n_atoms, n_channels, n_times_atom)
+            The atoms to learn from the data.
+        """
         self.D_hat[k0] = self.get_max_error_dict(z_encoder)[0]
         z_encoder.set_D(self.D_hat)
+        return self.D_hat
 
     def update_D(self, z_encoder):
-        """Learn d's in time domain.
+        """Learn d's in time domain and update D_hat in z_encoder.
 
         Parameters
         ----------
@@ -330,6 +361,11 @@ class Rank1DSolver(BaseDSolver):
                        n_channels=self.n_channels)
 
     def get_D_shape(self):
+        """Returns the expected shape of the dictionary.
+
+        Note: For the 'greedy' strategy this does not return the actual
+        dictionary shape, but the final expected shape.
+        """
         return (self.n_atoms, self.n_channels + self.n_times_atom)
 
 
@@ -598,6 +634,11 @@ class DSolver(BaseDSolver):
         return prox_d(D_hat)
 
     def get_D_shape(self):
+        """Returns the expected shape of the dictionary.
+
+        Note: For the 'greedy' strategy this does not return the actual
+        dictionary shape, but the final expected shape.
+        """
         return (self.n_atoms, self.n_channels, self.n_times_atom)
 
     def grad(self, D, z_encoder):

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -252,6 +252,8 @@ class BaseDSolver:
 
         D_hat = self.init_strategy.initialize(X)
 
+        # if D_init is not an ndarray
+        # when D_init is an ndarray, the strategy has D_init attribute
         if not hasattr(self.init_strategy, 'D_init'):
             D_hat = self._windower.window(D_hat)
 

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -259,6 +259,11 @@ class BaseDSolver:
 
         return D_hat
 
+    def add_one_atom(self, z_encoder):
+        new_atom = self.get_max_error_dict(z_encoder)[0]
+        z_encoder.add_one_atom(new_atom)
+        z_encoder.update_z_hat()
+
     def update_D(self, z_encoder):
         """Learn d's in time domain.
 

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -249,6 +249,10 @@ class BaseDSolver:
 
         z_encoder.update_z_hat(self.D_hat)
 
+    def resample_atom(self, k0, z_encoder):
+        self.D_hat[k0] = self.get_max_error_dict(z_encoder)[0]
+        z_encoder.set_D(self.D_hat)
+
     def update_D(self, z_encoder):
         """Learn d's in time domain.
 

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -2,10 +2,64 @@ import numpy as np
 
 from .init_dict import DictGenerator, Rank1DictGenerator
 from .loss_and_gradient import gradient_uv, gradient_d
-from .update_d_multi import check_solver_and_constraints
 from .utils import check_random_state
 from .utils.convolution import numpy_convolve_uv
 from .utils.optim import fista, power_iteration
+
+
+def check_solver_and_constraints(rank1, solver_d, uv_constraint):
+    """Checks if solver_d and uv_constraint are compatible depending on
+    rank1 value.
+
+    - If rank1 is False, solver_d should be 'fista' and uv_constraint should be
+    'auto'.
+    - If rank1 is True;
+       - If solver_d is either 'alternate' or 'alternate_adaptive',
+         uv_constraint should be 'separate'.
+       - If solver_d is either 'joint' or 'fista', uv_constraint should be
+         'joint'.
+
+    Parameters
+    ----------
+    rank1: boolean
+        If set to True, learn rank 1 dictionary atoms.
+    solver_d : str in {'alternate' | 'alternate_adaptive' | 'fista' | 'joint' |
+    'auto'}
+        The solver to use for the d update.
+        - If rank1 is False, only option is 'fista'
+        - If rank1 is True, options are 'alternate', 'alternate_adaptive'
+          (default) or 'joint'
+    uv_constraint : str in {'joint' | 'separate' | 'auto'}
+        The kind of norm constraint on the atoms if using rank1=True.
+        If 'joint', the constraint is norm_2([u, v]) <= 1
+        If 'separate', the constraint is norm_2(u) <= 1 and norm_2(v) <= 1
+        If rank1 is False, then uv_constraint must be 'auto'.
+    """
+
+    if rank1:
+        if solver_d == 'auto':
+            solver_d = 'alternate_adaptive'
+        if 'alternate' in solver_d:
+            if uv_constraint == 'auto':
+                uv_constraint = 'separate'
+            else:
+                assert uv_constraint == 'separate', (
+                    "solver_d='alternate*' should be used with "
+                    f"uv_constraint='separate'. Got '{uv_constraint}'."
+                )
+        elif uv_constraint == 'auto' and solver_d in ['joint', 'fista']:
+            uv_constraint = 'joint'
+    else:
+        assert solver_d in ['auto', 'fista'], (
+            f"solver_d should be auto or fista. Got solver_d='{solver_d}'."
+        )
+        assert solver_d in ['auto', 'fista'] and uv_constraint == 'auto', (
+            "If rank1 is False, uv_constraint should be 'auto' "
+            f"and solver_d should be auto or fista. Got solver_d='{solver_d}' "
+            f"and uv_constraint='{uv_constraint}'."
+        )
+        solver_d = 'fista'
+    return solver_d, uv_constraint
 
 
 def get_solver_d(n_channels, n_atoms, n_times_atom,

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -86,12 +86,11 @@ class BaseDSolver:
 
     def __init__(self, n_channels, n_atoms, n_times_atom, solver_d,
                  uv_constraint, eps, max_iter, momentum, random_state,
-                 verbose, debug, rank1):
+                 verbose, debug):
 
         self.n_channels = n_channels
         self.n_atoms = n_atoms
         self.n_times_atom = n_times_atom
-        self.rank1 = rank1
         self.uv_constraint = uv_constraint
         self.eps = eps
         self.max_iter = max_iter
@@ -244,7 +243,7 @@ class Rank1DSolver(BaseDSolver):
 
         super().__init__(
             n_channels, n_atoms, n_times_atom, solver_d, uv_constraint, eps,
-            max_iter, momentum, random_state, verbose, debug, rank1=True
+            max_iter, momentum, random_state, verbose, debug
         )
 
         self.dict_generator = Rank1DictGenerator(
@@ -528,7 +527,7 @@ class DSolver(BaseDSolver):
 
         super().__init__(
             n_channels, n_atoms, n_times_atom, solver_d, uv_constraint, eps,
-            max_iter, momentum, random_state, verbose, debug, rank1=False
+            max_iter, momentum, random_state, verbose, debug
         )
 
         self.dict_generator = DictGenerator(

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -439,7 +439,7 @@ class AlternateDSolver(Rank1DSolver):
             return objective(uv)
 
         def op_Hu(u):
-            u = np.reshape(u, (z_encoder.n_atoms, n_channels))
+            u = np.reshape(u, (self.D_hat.shape[0], n_channels))
             uv = np.c_[u, v_hat]
             H_d = numpy_convolve_uv(z_encoder.ztz, uv)
             H_u = (H_d * uv[:, None, n_channels:]).sum(axis=2)
@@ -488,7 +488,7 @@ class AlternateDSolver(Rank1DSolver):
             return objective(uv)
 
         def op_Hv(v):
-            v = np.reshape(v, (z_encoder.n_atoms, z_encoder.n_times_atom))
+            v = np.reshape(v, (self.D_hat.shape[0], z_encoder.n_times_atom))
             uv = np.c_[u_hat, v]
             H_d = numpy_convolve_uv(z_encoder.ztz, uv)
             H_v = (H_d * uv[:, :n_channels, None]).sum(axis=1)
@@ -555,15 +555,17 @@ class AlternateDSolver(Rank1DSolver):
             # XXX - maybe replace with scipy.sparse.linalg.svds
             b_hat_0 = np.random.randn(uv_hat.size)
 
+            n_atoms = self.D_hat.shape[0]
+
             if variable == 'u':
                 b_hat_0 = b_hat_0.reshape(
-                    z_encoder.n_atoms, -1)[:, :z_encoder.n_channels].ravel()
-                n_points = z_encoder.n_atoms * z_encoder.n_channels
+                    n_atoms, -1)[:, :z_encoder.n_channels].ravel()
+                n_points = n_atoms * z_encoder.n_channels
                 L = power_iteration(op, n_points, b_hat_0=b_hat_0)
             elif variable == 'v':
                 b_hat_0 = b_hat_0.reshape(
-                    z_encoder.n_atoms, -1)[:, z_encoder.n_channels:].ravel()
-                n_points = z_encoder.n_atoms * z_encoder.n_times_atom
+                    n_atoms, -1)[:, z_encoder.n_channels:].ravel()
+                n_points = n_atoms * self.n_times_atom
 
             L = power_iteration(op, n_points, b_hat_0=b_hat_0)
 

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -163,6 +163,7 @@ class BaseDSolver:
         self.rng = check_random_state(random_state)
         self.verbose = verbose
         self.debug = debug
+        self.D_init = D_init
 
         self.init_strategy = get_init_strategy(
             n_times_atom, self.get_D_shape(), self.rng, D_init, D_init_params
@@ -224,9 +225,7 @@ class BaseDSolver:
 
         D_hat = self.init_strategy.initialize(X)
 
-        # if D_init is not an ndarray
-        # when D_init is an ndarray, the strategy has D_init attribute
-        if not hasattr(self.init_strategy, 'D_init'):
+        if not isinstance(self.D_init, np.ndarray):
             D_hat = self._windower.window(D_hat)
 
         self.D_hat = self.prox(D_hat)

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -207,6 +207,32 @@ class BaseDSolver:
 
         return grad
 
+    def init_dictionary(self, X):
+        """Returns a dictionary for the signal X depending on D_init value.
+
+        Parameters
+        ----------
+        X: array, shape (n_trials, n_channels, n_times)
+            The data on which to perform CSC.
+
+        Return
+        ------
+        D : array shape (n_atoms, n_channels + n_times_atom) or
+                  shape (n_atoms, n_channels, n_times_atom)
+            The initial atoms to learn from the data.
+        """
+
+        D_hat = self.init_strategy.initialize(X)
+
+        # if D_init is not an ndarray
+        # when D_init is an ndarray, the strategy has D_init attribute
+        if not hasattr(self.init_strategy, 'D_init'):
+            D_hat = self._windower.window(D_hat)
+
+        self.D_hat = self.prox(D_hat)
+
+        return self.D_hat
+
     def get_max_error_dict(self, z_encoder):
         """Get the maximal reconstruction error patch from the data as a new atom
 
@@ -234,32 +260,6 @@ class BaseDSolver:
         d0 = self._windower.window(d0)
 
         return self.prox(d0)
-
-    def init_dictionary(self, X):
-        """Returns a dictionary for the signal X depending on D_init value.
-
-        Parameters
-        ----------
-        X: array, shape (n_trials, n_channels, n_times)
-            The data on which to perform CSC.
-
-        Return
-        ------
-        D : array shape (n_atoms, n_channels + n_times_atom) or
-                  shape (n_atoms, n_channels, n_times_atom)
-            The initial atoms to learn from the data.
-        """
-
-        D_hat = self.init_strategy.initialize(X)
-
-        # if D_init is not an ndarray
-        # when D_init is an ndarray, the strategy has D_init attribute
-        if not hasattr(self.init_strategy, 'D_init'):
-            D_hat = self._windower.window(D_hat)
-
-        self.D_hat = self.prox(D_hat)
-
-        return self.D_hat
 
     def add_one_atom(self, z_encoder):
         """Adds one atom to D_hat and updates D_hat in z_encoder.

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .init_dict import DictGenerator, Rank1DictGenerator
+from .init_dict import Dictionary, Rank1Dictionary
 from .loss_and_gradient import gradient_uv, gradient_d
 from .utils import check_random_state
 from .utils.convolution import numpy_convolve_uv
@@ -304,7 +304,7 @@ class Rank1DSolver(BaseDSolver):
             max_iter, momentum, random_state, verbose, debug
         )
 
-        self.dict_generator = Rank1DictGenerator(
+        self.dict_generator = Rank1Dictionary(
             self.n_channels, self.n_atoms, self.n_times_atom,
             self.rng, window, self.uv_constraint
         )
@@ -561,7 +561,7 @@ class DSolver(BaseDSolver):
             max_iter, momentum, random_state, verbose, debug
         )
 
-        self.dict_generator = DictGenerator(
+        self.dict_generator = Dictionary(
             self.n_channels, self.n_atoms, self.n_times_atom, self.rng, window
         )
 

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -271,10 +271,13 @@ class BaseDSolver:
 
         Returns
         -------
-        D_hat : array, shape (n_atoms, n_channels + n_times_atom) or
-                             (n_atoms, n_channels, n_times_atom)
-            The atoms to learn from the data.
+        D_hat : array, shape (k+1, n_channels + n_times_atom) or
+                             (k+1, n_channels, n_times_atom)
+            The atoms to learn from the data, where k < n_atoms is the initial
+        number of atoms in the dictionary before adding an atom.
         """
+        # XXX should it check the number of atoms in D_hat is smaller
+        # than n_atoms
         new_atom = self.get_max_error_dict(z_encoder)[0]
 
         self.D_hat = np.concatenate([self.D_hat, new_atom[None]])

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .init_dict import DictStrategy, Rank1DictStrategy
+from .init_dict import DictGenerator, Rank1DictGenerator
 from .loss_and_gradient import gradient_uv, gradient_d
 from .update_d_multi import prox_d, prox_uv, check_solver_and_constraints
 from .utils import check_random_state
@@ -167,8 +167,8 @@ class BaseDSolver:
             The initial atoms to learn from the data.
         """
 
-        self.dict_strategy.set_dict_generator(D_init)
-        D_hat = self.dict_strategy.get_dict(X, D_init_params)
+        self.dict_generator.set_strategy(D_init)
+        D_hat = self.dict_generator.get_dict(X, D_init_params)
 
         if not isinstance(D_init, np.ndarray):
             D_hat = self.windower.window(D_hat)
@@ -220,7 +220,7 @@ class Rank1DSolver(BaseDSolver):
             eps, max_iter, momentum, random_state, verbose, debug, rank1=True
         )
 
-        self.dict_strategy = Rank1DictStrategy(
+        self.dict_generator = Rank1DictGenerator(
             self.n_channels, self.n_atoms, self.n_times_atom, self.rng
         )
 
@@ -531,7 +531,7 @@ class DSolver(BaseDSolver):
             eps, max_iter, momentum, random_state, verbose, debug, rank1=False
         )
 
-        self.dict_strategy = DictStrategy(
+        self.dict_generator = DictGenerator(
             self.n_channels, self.n_atoms, self.n_times_atom, self.rng
         )
 

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .init_dict import InitStrategy, Rank1InitStrategy, get_strategy
+from .init_dict import InitStrategy, Rank1InitStrategy, get_generator
 from .loss_and_gradient import gradient_uv, gradient_d
 from .update_d_multi import prox_d, prox_uv, check_solver_and_constraints
 from .utils import check_random_state
@@ -167,8 +167,8 @@ class BaseDSolver:
             The initial atoms to learn from the data.
         """
 
-        strategy = get_strategy(self.dict_strategy, D_init)
-        D_hat = strategy.get_dict(X, D_init_params)
+        dict_generator = get_generator(self.dict_strategy, D_init)
+        D_hat = dict_generator.get_dict(X, D_init_params)
 
         if not isinstance(D_init, np.ndarray):
             D_hat = self.windower.window(D_hat)

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -261,7 +261,8 @@ class BaseDSolver:
 
     def add_one_atom(self, z_encoder):
         new_atom = self.get_max_error_dict(z_encoder)[0]
-        z_encoder.add_one_atom(new_atom)
+
+        z_encoder.D_hat = np.concatenate([z_encoder.D_hat, new_atom[None]])
         z_encoder.update_z_hat()
 
     def update_D(self, z_encoder):

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -180,7 +180,7 @@ class BaseDSolver:
 
             D = self.dict_util.prox(D)
 
-            return self.dict_util.dewindow(D)
+            return self.dict_util.remove_window(D)
 
         return prox
 
@@ -266,7 +266,7 @@ class BaseDSolver:
 
         assert z_encoder.n_channels == self.n_channels
 
-        D_hat0 = self.dict_util.dewindow(self.D_hat)
+        D_hat0 = self.dict_util.remove_window(self.D_hat)
 
         D_hat, pobj = fista(
             self._get_objective(z_encoder), self._get_grad(z_encoder),
@@ -357,7 +357,7 @@ class AlternateDSolver(Rank1DSolver):
         """
         assert z_encoder.n_channels == self.n_channels
 
-        uv_hat = self.dict_util.dewindow(self.D_hat)
+        uv_hat = self.dict_util.remove_window(self.D_hat)
 
         objective = self._get_objective(z_encoder)
 
@@ -454,7 +454,7 @@ class AlternateDSolver(Rank1DSolver):
 
             v /= np.maximum(1., np.linalg.norm(v, axis=1, keepdims=True))
 
-            return self.dict_util.simple_dewindow(v)
+            return self.dict_util.simple_remove_window(v)
 
         def obj(v):
             uv = np.c_[u_hat, v]

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -233,19 +233,19 @@ class BaseDSolver:
         return self.prox(d0)
 
     def init_dictionary(self, X, D_init=None, D_init_params=dict()):
-        """Returns an initial dictionary for the signal X.
+        """Returns a dictionary for the signal X depending on D_init value.
 
         Parameter
         ---------
         X: array, shape (n_trials, n_channels, n_times)
             The data on which to perform CSC.
-        D_init : array or {'kmeans' | 'ssa' | 'chunk' | 'random'}
+        D_init : {'kmeans' | 'ssa' | 'chunk' | 'random'}
+                 or array, shape (n_atoms, n_channels + n_times_atom) or
+                             (n_atoms, n_channels, n_times_atom)
             The initialization scheme for the dictionary or the initial
-            atoms. The shape should match the required dictionary shape, ie if
-            rank1 is True, (n_atoms, n_channels + n_times_atom) and else
-            (n_atoms, n_channels, n_times_atom)
+            atoms.
         D_init_params : dict
-            Dictionnary of parameters for the kmeans init method.
+            Dictionary of parameters for the kmeans init method.
 
         Return
         ------

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -264,7 +264,7 @@ class BaseDSolver:
 
         self.D_hat = np.concatenate([self.D_hat, new_atom[None]])
 
-        z_encoder.update_z_hat(self.D_hat)
+        z_encoder.set_D(self.D_hat)
 
     def resample_atom(self, k0, z_encoder):
         self.D_hat[k0] = self.get_max_error_dict(z_encoder)[0]

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -276,8 +276,8 @@ class BaseDSolver:
             The atoms to learn from the data, where k < n_atoms is the initial
         number of atoms in the dictionary before adding an atom.
         """
-        # XXX should it check the number of atoms in D_hat is smaller
-        # than n_atoms
+        assert self.D_hat.shape[0] < self.n_atoms
+
         new_atom = self.get_max_error_dict(z_encoder)[0]
 
         self.D_hat = np.concatenate([self.D_hat, new_atom[None]])

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -454,7 +454,7 @@ class AlternateDSolver(Rank1DSolver):
 
             v /= np.maximum(1., np.linalg.norm(v, axis=1, keepdims=True))
 
-            return self.dict_util.simple_remove_window(v)
+            return self.dict_util.remove_simple_window(v)
 
         def obj(v):
             uv = np.c_[u_hat, v]

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -369,6 +369,8 @@ class AlphaCSCEncoder(BaseZEncoder):
 
         nb_missing_atoms = D.shape[0] - self.z_hat.shape[1]
 
+        assert nb_missing_atoms >= 0
+
         if nb_missing_atoms > 0:
             self.z_hat = np.concatenate(
                 [self.z_hat, self._get_new_z_hat(nb_missing_atoms)], axis=1

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -244,19 +244,12 @@ class BaseZEncoder:
         """
         raise NotImplementedError()
 
-    def update_reg(self, is_shared):
+    def update_reg(self):
         """
         Update the regularization parameter.
 
-        Parameters
-        ----------
-        is_shared : bool
-            if the regularization parameter is fixed as a ratio of its
-            maximal value at init i.e. reg_used = reg * lmbd_max(uv_init)
         """
-        self.reg = self.reg * get_lambda_max(self.X, self.D_hat)
-        if is_shared:
-            self.reg = self.reg.max()
+        self.reg = self.reg * get_lambda_max(self.X, self.D_hat).max()
 
     def get_constants(self):
         """
@@ -582,14 +575,8 @@ class DicodileEncoder(BaseZEncoder):
     def update_reg(self, is_shared):
         """
         Update the regularization parameter.
-
-        Parameters
-        ----------
-        is_shared : bool
-            if the regularization parameter is fixed as a ratio of its
-            maximal value at init i.e. reg_used = reg * lmbd_max(uv_init)
         """
-        super().update_reg(is_shared)
+        super().update_reg()
         self._encoder.set_worker_params({'reg': self.reg})  # XXX
 
     def __enter__(self):

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -381,15 +381,25 @@ class AlphaCSCEncoder(BaseZEncoder):
     def set_D(self, D):
         self.D_hat = D
 
-    def set_reg(self, reg):
-        self.reg = reg
-
     def add_one_atom(self, new_atom):
         assert new_atom.shape == (self.n_times_atom + self.X.shape[1],)
         self.D_hat = np.concatenate([self.D_hat, new_atom[None]])
         self.z_hat = np.concatenate(
             [self.z_hat, self._get_new_z_hat(1)], axis=1
         )
+
+    def update_z_hat(self):
+        n_atoms = self.z_hat.shape[1]
+        # XXX would it require a more complex check or adjustment. We are
+        # assuming that the number of atoms increase one by one.
+        # check shape and adjust z_hat
+        if self.D_hat.shape[0] < n_atoms:
+            self.z_hat = np.concatenate(
+                [self.z_hat, self._get_new_z_hat(1)], axis=1
+            )
+
+    def set_reg(self, reg):
+        self.reg = reg
 
     def get_z_hat(self):
         return self.z_hat

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -381,7 +381,8 @@ class AlphaCSCEncoder(BaseZEncoder):
     def set_D(self, D):
         self.D_hat = D
 
-    def update_z_hat(self):
+    def update_z_hat(self, D):
+        self.D_hat = D
         # XXX would it require a more complex check or adjustment. We are
         # assuming that the number of atoms increase one by one.
         # check shape and adjust z_hat

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -244,12 +244,20 @@ class BaseZEncoder:
         """
         raise NotImplementedError()
 
-    def update_reg(self):
+    def update_reg(self, is_per_atom):
         """
         Update the regularization parameter.
 
+        Parameters
+        ----------
+        is_per_atom: bool
+            True if lmbd_max='per_atom'; False otherwise
+
         """
-        self.reg = self.reg * get_lambda_max(self.X, self.D_hat).max()
+        self.reg = self.reg * get_lambda_max(self.X, self.D_hat)
+
+        if not is_per_atom:
+            self.reg = self.reg.max()
 
     def get_constants(self):
         """
@@ -574,11 +582,16 @@ class DicodileEncoder(BaseZEncoder):
         self.D_hat = D
         self._encoder.set_worker_D(D)
 
-    def update_reg(self):
+    def update_reg(self, is_per_atom):
         """
         Update the regularization parameter.
-        """
-        super().update_reg()
+
+        Parameters
+        ----------
+        is_per_atom: bool
+            True if lmbd_max='per_atom'; False otherwise
+       """
+        super().update_reg(is_per_atom)
         self._encoder.set_worker_params({'reg': self.reg})  # XXX
 
     def __enter__(self):

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -381,19 +381,12 @@ class AlphaCSCEncoder(BaseZEncoder):
     def set_D(self, D):
         self.D_hat = D
 
-    def add_one_atom(self, new_atom):
-        assert new_atom.shape == (self.n_times_atom + self.X.shape[1],)
-        self.D_hat = np.concatenate([self.D_hat, new_atom[None]])
-        self.z_hat = np.concatenate(
-            [self.z_hat, self._get_new_z_hat(1)], axis=1
-        )
-
     def update_z_hat(self):
-        n_atoms = self.z_hat.shape[1]
         # XXX would it require a more complex check or adjustment. We are
         # assuming that the number of atoms increase one by one.
         # check shape and adjust z_hat
-        if self.D_hat.shape[0] < n_atoms:
+
+        if self.z_hat.shape[1] < self.n_atoms:
             self.z_hat = np.concatenate(
                 [self.z_hat, self._get_new_z_hat(1)], axis=1
             )

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -374,15 +374,11 @@ class AlphaCSCEncoder(BaseZEncoder):
     def set_D(self, D):
         self.D_hat = D
 
-    def update_z_hat(self, D):
-        self.D_hat = D
-        # XXX would it require a more complex check or adjustment. We are
-        # assuming that the number of atoms increase one by one.
-        # check shape and adjust z_hat
+        nb_missing_atoms = D.shape[0] - self.z_hat.shape[1]
 
-        if self.z_hat.shape[1] < self.n_atoms:
+        if nb_missing_atoms > 0:
             self.z_hat = np.concatenate(
-                [self.z_hat, self._get_new_z_hat(1)], axis=1
+                [self.z_hat, self._get_new_z_hat(nb_missing_atoms)], axis=1
             )
 
     def get_z_hat(self):

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -260,18 +260,6 @@ class BaseZEncoder:
         return dict(n_channels=self.n_channels, XtX=self.XtX,
                     ztz=self.ztz, ztX=self.ztX)
 
-    def add_one_atom(self, new_atom):
-        """
-        Add one atom to the dictionary and extend z_hat
-        to match the new dimensions.
-
-        Parameters
-        ----------
-        new_atom : array, shape (n_channels + n_times_atom)
-            A new atom to add to the dictionary.
-        """
-        raise NotImplementedError()
-
     def __enter__(self):
         return self
 
@@ -603,19 +591,6 @@ class DicodileEncoder(BaseZEncoder):
               Regularization parameter
         """
         self._encoder.set_worker_params({'reg': reg})  # XXX
-
-    def add_one_atom(self, new_atom):
-        """
-        Add one atom to the dictionary and extend z_hat
-        to match the new dimensions.
-
-        Parameters
-        ----------
-        new_atom : array, shape (n_channels + n_times_atom)
-            A new atom to add to the dictionary.
-        """
-        raise NotImplementedError(
-            "Greedy learning is not available in DiCoDiLe")
 
     def __enter__(self):
         # XXX run init here?

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -593,7 +593,7 @@ class DicodileEncoder(BaseZEncoder):
             if the regularization parameter is fixed as a ratio of its
             maximal value at init i.e. reg_used = reg * lmbd_max(uv_init)
         """
-        super().update_reg()
+        super().update_reg(is_shared)
         self._encoder.set_worker_params({'reg': self.reg})  # XXX
 
     def __enter__(self):

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -572,7 +572,7 @@ class DicodileEncoder(BaseZEncoder):
         self.D_hat = D
         self._encoder.set_worker_D(D)
 
-    def update_reg(self, is_shared):
+    def update_reg(self):
         """
         Update the regularization parameter.
         """

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -3,7 +3,7 @@ import numpy as np
 from .utils import construct_X_multi
 from .utils.dictionary import get_D_shape
 from .update_z_multi import update_z_multi
-from .utils.dictionary import _patch_reconstruction_error
+from .utils.dictionary import _patch_reconstruction_error, get_uv
 from .loss_and_gradient import compute_objective
 
 DEFAULT_TOL_Z = 1e-3
@@ -372,7 +372,11 @@ class AlphaCSCEncoder(BaseZEncoder):
 
         n_channels = self.X.shape[1]
         *_, n_times_atom = get_D_shape(self.D_hat, n_channels)
-        return self.X[n0, :, t0:t0 + n_times_atom][None]
+
+        patch = self.X[n0, :, t0:t0 + n_times_atom][None]
+        if self.D_hat.ndim == 2:
+            patch = get_uv(patch)
+        return patch
 
     def set_D(self, D):
         self.D_hat = D
@@ -535,7 +539,11 @@ class DicodileEncoder(BaseZEncoder):
 
         n_channels = self.X.shape[1]
         *_, n_times_atom = get_D_shape(self.D_hat, n_channels)
-        return self.X[n0, :, t0:t0 + n_times_atom][None]
+
+        patch = self.X[n0, :, t0:t0 + n_times_atom][None]
+        if self.D_hat.ndim == 2:
+            patch = get_uv(patch)
+        return patch
 
     def get_z_hat(self):
         """

--- a/alphacsc/convolutional_dictionary_learning.py
+++ b/alphacsc/convolutional_dictionary_learning.py
@@ -93,7 +93,7 @@ DOC_FMT = """{short_desc}
     D_init : str or array
         The initial atoms with shape (n_atoms, n_channels + n_times_atoms) or
         (n_atoms, n_channels, n_times_atom) or an initialization scheme str in
-        {{'kmeans' | 'ssa' | 'chunk' | 'random'}}.
+        {{'kmeans' | 'ssa' | 'chunk' | 'random' | 'greedy'}}.
     D_init_params : dict
         Dictionnary of parameters for the kmeans init method.
 

--- a/alphacsc/convolutional_dictionary_learning.py
+++ b/alphacsc/convolutional_dictionary_learning.py
@@ -11,7 +11,7 @@ from .update_z_multi import update_z_multi
 from .utils.dictionary import get_D, get_uv
 from .learn_d_z_multi import learn_d_z_multi
 from .loss_and_gradient import construct_X_multi
-from .update_d_multi import check_solver_and_constraints
+from ._d_solver import check_solver_and_constraints
 
 
 DOC_FMT = """{short_desc}

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -96,10 +96,11 @@ class RandomStrategy():
     def __init__(self, shape, random_state):
 
         self.shape = shape
-        self.rng = check_random_state(random_state)
+        self.random_state = random_state
 
     def initialize(self, X):
-        return self.rng.randn(*self.shape)
+        rng = check_random_state(self.random_state)
+        return rng.randn(*self.shape)
 
 
 class ChunkStrategy():
@@ -122,17 +123,18 @@ class ChunkStrategy():
         self.n_atoms = shape[0]
         self.n_times_atom = n_times_atom
         self.rank1 = True if len(shape) == 2 else False
-        self.rng = check_random_state(random_state)
+        self.random_state = random_state
 
     def initialize(self, X):
+        rng = check_random_state(self.random_state)
         n_trials, n_channels, n_times = X.shape
 
         D_hat = np.zeros(
             (self.n_atoms, n_channels, self.n_times_atom))
 
         for i_atom in range(self.n_atoms):
-            i_trial = self.rng.randint(n_trials)
-            t0 = self.rng.randint(n_times - self.n_times_atom)
+            i_trial = rng.randint(n_trials)
+            t0 = rng.randint(n_times - self.n_times_atom)
             D_hat[i_atom] = X[i_trial, :, t0:t0 + self.n_times_atom]
 
         if self.rank1:
@@ -163,14 +165,15 @@ class KMeansStrategy():
         self.n_atoms = shape[0]
         self.n_times_atom = n_times_atom
         self.rank1 = True if len(shape) == 2 else False
-        self.rng = check_random_state(random_state)
+        self.random_state = random_state
         self.D_init_params = D_init_params
 
     def initialize(self, X):
+        rng = check_random_state(self.random_state)
         n_channels = X.shape[1]
 
         D_hat = kmeans_init(X, self.n_atoms, self.n_times_atom,
-                            random_state=self.rng, **self.D_init_params)
+                            random_state=rng, **self.D_init_params)
 
         if not self.rank1:
             D_hat = get_D(D_hat, n_channels)
@@ -197,14 +200,15 @@ class SSAStrategy():
         self.n_atoms = shape[0]
         self.n_times_atom = n_times_atom
         self.rank1 = True if len(shape) == 2 else False
-        self.rng = check_random_state(random_state)
+        self.random_state = random_state
 
     def initialize(self, X):
+        rng = check_random_state(self.random_state)
         n_channels = X.shape[1]
 
-        u_hat = self.rng.randn(self.n_atoms, n_channels)
+        u_hat = rng.randn(self.n_atoms, n_channels)
         v_hat = ssa_init(X, self.n_atoms, self.n_times_atom,
-                         random_state=self.rng)
+                         random_state=rng)
         D_hat = np.c_[u_hat, v_hat]
 
         if not self.rank1:

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -24,7 +24,7 @@ ried = custom_distances.roll_invariant_euclidean_distances
 tied = custom_distances.translation_invariant_euclidean_distances
 
 
-class BaseDictGenerator():
+class BaseDictionary():
 
     def __init__(self, n_channels, n_atoms, n_times_atom, random_state,
                  window):
@@ -91,7 +91,7 @@ class BaseDictGenerator():
                                       ' with parameter {}.'.format(D_init))
 
 
-class DictGenerator(BaseDictGenerator):
+class Dictionary(BaseDictionary):
 
     def _init_windower(self):
         self.windower = SimpleWindower(self.n_times_atom)
@@ -106,7 +106,7 @@ class DictGenerator(BaseDictGenerator):
         return get_D(D_hat, self.n_channels)
 
 
-class Rank1DictGenerator(BaseDictGenerator):
+class Rank1Dictionary(BaseDictionary):
 
     def __init__(self, n_channels, n_atoms, n_times_atom, random_state,
                  window, uv_constraint):

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -70,8 +70,8 @@ class BaseDictionaryUtil():
     def simple_window(self, D_hat):
         return self._windower.simple_window(D_hat)
 
-    def simple_remove_window(self, D_hat):
-        return self._windower.simple_remove_window(D_hat)
+    def remove_simple_window(self, D_hat):
+        return self._windower.remove_simple_window(D_hat)
 
     def prox(self, D_hat):
         raise NotImplementedError()

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -24,7 +24,7 @@ ried = custom_distances.roll_invariant_euclidean_distances
 tied = custom_distances.translation_invariant_euclidean_distances
 
 
-class BaseDictionary():
+class BaseDictionaryUtil():
 
     def __init__(self, n_channels, n_atoms, n_times_atom, random_state,
                  window, D_init, D_init_params):
@@ -67,8 +67,11 @@ class BaseDictionary():
 
         if not hasattr(self.strategy, 'D_init'):
             D_hat = self.window(D_hat)
-        self.D_hat = self.prox(D_hat)
-        return self.D_hat
+        D_hat = self.prox(D_hat)
+        return D_hat
+
+    def add_one_atom(self, D_hat, new_atom):
+        return np.concatenate([D_hat, new_atom[None]])
 
     def wrap(self, D_hat):
         return D_hat
@@ -94,7 +97,7 @@ class BaseDictionary():
                                       ' with parameter {}.'.format(D_init))
 
 
-class Dictionary(BaseDictionary):
+class DictionaryUtil(BaseDictionaryUtil):
 
     def _init_windower(self):
         self.windower = SimpleWindower(self.n_times_atom)
@@ -109,7 +112,7 @@ class Dictionary(BaseDictionary):
         return get_D(D_hat, self.n_channels)
 
 
-class Rank1Dictionary(BaseDictionary):
+class Rank1DictionaryUtil(BaseDictionaryUtil):
 
     def __init__(self, n_channels, n_atoms, n_times_atom, random_state,
                  window, D_init, D_init_params, uv_constraint):

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -62,7 +62,7 @@ class BaseDictionary():
     def get_shape(self):
         raise NotImplementedError()
 
-    def init(self, X):
+    def initialize(self, X):
         D_hat = self.strategy.init(X)
 
         if not hasattr(self.strategy, 'D_init'):

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -61,8 +61,9 @@ class BaseDictGenerator():
 
     def get_dict(self, X, D_init_params):
         D_hat = self.strategy.get_dict(X, D_init_params)
-        # XXX this windows also isinstance(D_init, np.ndarray) case
-        D_hat = self.window(D_hat)
+
+        if not hasattr(self.strategy, 'D_init'):
+            D_hat = self.window(D_hat)
         D_hat = self.prox(D_hat)
         return D_hat
 

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -23,25 +23,54 @@ ried = custom_distances.roll_invariant_euclidean_distances
 tied = custom_distances.translation_invariant_euclidean_distances
 
 
-def get_dict_strategy(n_times_atom, shape, rng, D_init, D_init_params):
+def get_init_strategy(n_times_atom, shape, random_state, D_init,
+                      D_init_params):
+    """Returns dictionary initialization strategy.
+
+    Parameters
+    ----------
+    n_times_atom : int
+        The support of the atom.
+    shape: tuple
+        Expected shape of the dictionary. (n_atoms, n_channels + n_times_atoms)
+    or (n_atoms, n_channels, n_times_atom)
+    random_state: int or np.random.RandomState
+        A seed to generate a RandomState instance or the instance itself.
+    D_init : str or array, shape (n_atoms, n_channels + n_times_atoms) or \
+                           shape (n_atoms, n_channels, n_times_atom)
+        The initial atoms or an initialization scheme in
+        {'kmeans' | 'ssa' | 'chunk' | 'random' | 'greedy'}.
+    D_init_params : dict
+        Dictionnary of parameters for the kmeans init method.
+    """
     if isinstance(D_init, np.ndarray):
         return IdentityStrategy(shape, D_init)
     elif D_init is None or D_init == 'random':
-        return RandomStrategy(shape, rng)
+        return RandomStrategy(shape, random_state)
     elif D_init == 'chunk':
-        return ChunkStrategy(n_times_atom, shape, rng)
+        return ChunkStrategy(n_times_atom, shape, random_state)
     elif D_init == "kmeans":
-        return KMeansStrategy(n_times_atom, shape, rng, D_init_params)
+        return KMeansStrategy(n_times_atom, shape, random_state, D_init_params)
     elif D_init == 'ssa':
-        return SSAStrategy(n_times_atom, shape, rng)
+        return SSAStrategy(n_times_atom, shape, random_state)
     elif D_init == 'greedy':
-        return GreedyStrategy(shape, rng)
+        return GreedyStrategy(shape, random_state)
     else:
         raise NotImplementedError('It is not possible to initialize uv'
                                   ' with parameter {}.'.format(D_init))
 
 
 class IdentityStrategy():
+    """A class that creates a dictionary from a specified array.
+
+    Parameters
+    ----------
+    shape: tuple
+        Expected shape of the dictionary. (n_atoms, n_channels + n_times_atoms)
+    or (n_atoms, n_channels, n_times_atom)
+    D_init : array of shape (n_atoms, n_channels + n_times_atoms) or \
+                      shape (n_atoms, n_channels, n_times_atom)
+    """
 
     def __init__(self, shape, D_init):
 
@@ -53,24 +82,47 @@ class IdentityStrategy():
 
 
 class RandomStrategy():
+    """A class that creates a random dictionary for a specified shape.
 
-    def __init__(self, shape, rng):
+    Parameters
+    ----------
+    shape: tuple
+        Expected shape of the dictionary. (n_atoms, n_channels + n_times_atoms)
+    or (n_atoms, n_channels, n_times_atom)
+    random_state: int or np.random.RandomState
+        A seed to generate a RandomState instance or the instance itself.
+    """
+
+    def __init__(self, shape, random_state):
 
         self.shape = shape
-        self.rng = rng
+        self.rng = check_random_state(random_state)
 
     def initialize(self, X):
         return self.rng.randn(*self.shape)
 
 
 class ChunkStrategy():
+    """A class that creates a random dictionary for a specified shape with
+    'chunk' strategy.
 
-    def __init__(self, n_times_atom, shape, rng):
+    Parameters
+    ----------
+    n_times_atom : int
+        The support of the atom.
+    shape: tuple
+        Expected shape of the dictionary. (n_atoms, n_channels + n_times_atoms)
+    or (n_atoms, n_channels, n_times_atom)
+    random_state: int or np.random.RandomState
+        A seed to generate a RandomState instance or the instance itself.
+    """
+
+    def __init__(self, n_times_atom, shape, random_state):
 
         self.n_atoms = shape[0]
         self.n_times_atom = n_times_atom
         self.rank1 = True if len(shape) == 2 else False
-        self.rng = rng
+        self.rng = check_random_state(random_state)
 
     def initialize(self, X):
         n_trials, n_channels, n_times = X.shape
@@ -90,13 +142,28 @@ class ChunkStrategy():
 
 
 class KMeansStrategy():
+    """A class that creates a random dictionary for a specified shape with
+    'kmeans' strategy.
 
-    def __init__(self, n_times_atom, shape, rng, D_init_params):
+    Parameters
+    ----------
+    n_times_atom : int
+        The support of the atom.
+    shape: tuple
+        Expected shape of the dictionary. (n_atoms, n_channels + n_times_atoms)
+    or (n_atoms, n_channels, n_times_atom)
+    random_state: int or np.random.RandomState
+        A seed to generate a RandomState instance or the instance itself.
+    D_init_params : dict
+        Dictionnary of parameters for the kmeans init method.
+    """
+
+    def __init__(self, n_times_atom, shape, random_state, D_init_params):
 
         self.n_atoms = shape[0]
         self.n_times_atom = n_times_atom
         self.rank1 = True if len(shape) == 2 else False
-        self.rng = rng
+        self.rng = check_random_state(random_state)
         self.D_init_params = D_init_params
 
     def initialize(self, X):
@@ -111,13 +178,26 @@ class KMeansStrategy():
 
 
 class SSAStrategy():
+    """A class that creates a random dictionary for a specified shape with
+    'ssa' strategy.
 
-    def __init__(self, n_times_atom, shape, rng):
+    Parameters
+    ----------
+    n_times_atom : int
+        The support of the atom.
+    shape: tuple
+        Expected shape of the dictionary. (n_atoms, n_channels + n_times_atoms)
+    or (n_atoms, n_channels, n_times_atom)
+    random_state: int or np.random.RandomState
+        A seed to generate a RandomState instance or the instance itself.
+    """
+
+    def __init__(self, n_times_atom, shape, random_state):
 
         self.n_atoms = shape[0]
         self.n_times_atom = n_times_atom
         self.rank1 = True if len(shape) == 2 else False
-        self.rng = rng
+        self.rng = check_random_state(random_state)
 
     def initialize(self, X):
         n_channels = X.shape[1]
@@ -134,6 +214,17 @@ class SSAStrategy():
 
 
 class GreedyStrategy(RandomStrategy):
+    """A class that creates a random dictionary for a specified shape and
+    removes all elements.
+
+    Parameters
+    ----------
+    shape: tuple
+        Expected shape of the dictionary. (n_atoms, n_channels + n_times_atoms)
+    or (n_atoms, n_channels, n_times_atom)
+    random_state: int or np.random.RandomState
+        A seed to generate a RandomState instance or the instance itself.
+    """
 
     def initialize(self, X):
         D_hat = super().initialize(X)
@@ -147,34 +238,34 @@ def init_dictionary(X, n_atoms, n_times_atom, uv_constraint='separate',
 
     Parameter
     ---------
-    X: array, shape (n_trials, n_channels, n_times)
+    X: array, shape(n_trials, n_channels, n_times)
         The data on which to perform CSC.
-    n_atoms : int
+    n_atoms: int
         The number of atoms to learn.
-    n_times_atom : int
+    n_times_atom: int
         The support of the atom.
-    uv_constraint : str in {'joint' | 'separate'}
+    uv_constraint: str in {'joint' | 'separate'}
         The kind of norm constraint on the atoms:
         If 'joint', the constraint is norm_2([u, v]) <= 1
         If 'separate', the constraint is norm_2(u) <= 1 and norm_2(v) <= 1
-    rank1 : boolean
+    rank1: boolean
         If set to True, use a rank 1 dictionary.
-    window : boolean
+    window: boolean
         If True, multiply the atoms with a temporal Tukey window.
-    D_init : array or {'kmeans' | 'ssa' | 'chunk' | 'random'}
+    D_init: array or {'kmeans' | 'ssa' | 'chunk' | 'random'}
         The initialization scheme for the dictionary or the initial
         atoms. The shape should match the required dictionary shape, ie if
         rank1 is True, (n_atoms, n_channels + n_times_atom) and else
         (n_atoms, n_channels, n_times_atom)
-    D_init_params : dict
+    D_init_params: dict
         Dictionnary of parameters for the kmeans init method.
-    random_state : int | None
+    random_state: int | None
         The random state.
 
     Return
     ------
-    D : array shape (n_atoms, n_channels + n_times_atom) or
-              shape (n_atoms, n_channels, n_times_atom)
+    D: array shape(n_atoms, n_channels + n_times_atom) or
+              shape(n_atoms, n_channels, n_times_atom)
         The initial atoms to learn from the data.
     """
     n_trials, n_channels, n_times = X.shape

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -85,7 +85,7 @@ class BaseDictionary():
         elif D_init == 'ssa':
             self.strategy = SSAStrategy(self)
         elif D_init == 'greedy':
-            raise NotImplementedError()
+            self.strategy = GreedyStrategy(self)
         else:
             raise NotImplementedError('It is not possible to initialize uv'
                                       ' with parameter {}.'.format(D_init))
@@ -198,6 +198,13 @@ class SSAStrategy(BaseStrategy):
 
         D_hat = self.parent.wrap(D_hat)
         return D_hat
+
+
+class GreedyStrategy(BaseStrategy):
+
+    def init(self, X, D_init_params):
+        D_hat = self.rng.randn(*self.parent.get_shape())
+        return D_hat[:0]
 
 
 def init_dictionary(X, n_atoms, n_times_atom, uv_constraint='separate',

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -210,21 +210,24 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
         kwargs.update(algorithm_params)
 
         if algorithm == 'batch':
-            pobj, times, D_hat, z_hat = _batch_learn(greedy=False, **kwargs)
+            pobj, times = _batch_learn(greedy=False, **kwargs)
         elif algorithm == "greedy":
-            pobj, times, D_hat, z_hat = _batch_learn(greedy=True, **kwargs)
+            pobj, times = _batch_learn(greedy=True, **kwargs)
         elif algorithm == "online":
-            pobj, times, D_hat, z_hat = _online_learn(**kwargs)
+            pobj, times = _online_learn(**kwargs)
         elif algorithm == "stochastic":
             # For stochastic learning, set forgetting factor alpha of the
             # online algorithm to 0, making each step independent of previous
             # steps and set D-update max_iter to a low value (typically 1).
             kwargs['alpha'] = 0
-            pobj, times, D_hat, z_hat = _online_learn(**kwargs)
+            pobj, times = _online_learn(**kwargs)
         else:
             raise NotImplementedError(
                 "Algorithm '{}' is not implemented to learn dictionary atoms."
                 .format(algorithm))
+
+        D_hat = d_solver.D_hat
+        z_hat = z_encoder.get_z_hat()
 
         if sort_atoms:
             D_hat, z_hat = sort_atoms_by_explained_variances(
@@ -338,7 +341,7 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
                 and end_iter_func(z_encoder, pobj, ii)):
             break
 
-    return pobj, times, d_solver.D_hat, z_encoder.get_z_hat()
+    return pobj, times
 
 
 def _online_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
@@ -431,7 +434,7 @@ def _online_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
         if end_iter_func(z_encoder, pobj, ii):
             break
 
-    return pobj, times, d_solver.D_hat, z_encoder.get_z_hat()
+    return pobj, times
 
 
 def get_iteration_func(eps, stopping_pobj, callback, lmbd_max, name, verbose,

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -165,15 +165,15 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
 
     d_solver = get_solver_d(
         n_channels, n_atoms, n_times_atom, solver_d=solver_d, rank1=rank1,
-        uv_constraint=uv_constraint, window=window, random_state=random_state,
+        uv_constraint=uv_constraint, D_init=D_init,
+        D_init_params=D_init_params, window=window, random_state=random_state,
         **solver_d_kwargs
     )
 
     # initialization
     start = time.time()
 
-    D_hat = d_solver.init_dictionary(X, D_init=D_init,
-                                     D_init_params=D_init_params)
+    D_hat = d_solver.init_dictionary(X)
 
     init_duration = time.time() - start
 

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -239,10 +239,7 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
             if verbose > 1:
                 print(
                     "[{}] Compute the final z_hat with support freeze in "
-                    "{:.2f}s".format(
-                        name,
-                        time.time() -
-                        start_unbiased_z_hat))
+                    "{:.2f}s".format(name, time.time() - start_unbiased_z_hat))
 
         times[0] += init_duration
 
@@ -302,9 +299,6 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
         times.append(time.time() - start)
         pobj.append(z_encoder.get_cost())
 
-        # XXX to adapt to Encoder class, we must fetch z_hat at each iteration.
-        # XXX is that acceptable or not? (seems that DiCoDiLe does not require
-        # it)
         z_nnz = z_encoder.get_z_nnz()
         if verbose > 5:
             print(

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -290,7 +290,7 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
         if lmbd_max in ['per_atom', 'shared'] or (
                 lmbd_max == 'scaled' and ii == 0
         ):
-            z_encoder.update_reg(lmbd_max == 'shared')
+            z_encoder.update_reg()
 
             if verbose > 5:
                 print('[{}] lambda = {:.3e}'.format(name,
@@ -376,7 +376,7 @@ def _online_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
         if lmbd_max in ['per_atom', 'shared'] or (
                 lmbd_max == 'scaled' and ii == 0
         ):
-            z_encoder.update_reg(lmbd_max == 'shared')
+            z_encoder.update_reg()
 
             if verbose > 5:
                 print('[{}] lambda = {:.3e}'.format(name,

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -291,7 +291,7 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
             d_solver.add_one_atom(z_encoder)
 
         if lmbd_max in ['per_atom', 'shared'] or (
-                lmbd_max == 'per_atom' and ii == 1
+                lmbd_max == 'scaled' and ii == 0
         ):
             reg_ = set_reg(lmbd_max, d_solver.D_hat, z_encoder)
 
@@ -381,7 +381,7 @@ def _online_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
             print('[{}] CD iterations {} / {}'.format(name, ii, n_iter))
 
         if lmbd_max in ['per_atom', 'shared'] or (
-                lmbd_max == 'per_atom' and ii == 1
+                lmbd_max == 'scaled' and ii == 0
         ):
             reg_ = set_reg(lmbd_max, D_hat, z_encoder)
 

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -349,16 +349,7 @@ def _online_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
                   alpha=.8, batch_selection='random', batch_size=1,
                   name="online"):
 
-    X = z_encoder.X
-    D_hat = d_solver.D_hat
-    n_atoms = d_solver.n_atoms
-
-    n_trials, n_channels = X.shape[:2]
-    if D_hat.ndim == 2:
-        n_atoms, n_times_atom = D_hat.shape
-        n_times_atom -= n_channels
-    else:
-        n_atoms, _, n_times_atom = D_hat.shape
+    n_trials = z_encoder.n_trials
 
     # monitor cost function
     times = [0]

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -259,7 +259,7 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
                  lmbd_max='fixed', reg=None, verbose=0, greedy=False,
                  random_state=None, name="batch"):
 
-    n_atoms = z_encoder.n_atoms
+    n_atoms = d_solver.n_atoms
 
     if greedy:
         n_iter_by_atom = 1

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -289,6 +289,10 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
         ):
             z_encoder.update_reg(lmbd_max == 'shared')
 
+            if verbose > 5:
+                print('[{}] lambda = {:.3e}'.format(
+                    name, np.mean(z_encoder.reg)))
+
         # Compute z update
         start = time.time()
         z_encoder.compute_z()
@@ -370,6 +374,10 @@ def _online_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
                 lmbd_max == 'scaled' and ii == 0
         ):
             z_encoder.update_reg(lmbd_max == 'shared')
+
+            if verbose > 5:
+                print('[{}] lambda = {:.3e}'.format(
+                    name, np.mean(z_encoder.reg)))
 
         # Compute z update
         start = time.time()

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -248,8 +248,7 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
 
         # Rescale the solution to match the given scale of the problem
         z_hat *= std_X
-        reg *= std_X
-        z_encoder.set_reg(reg)
+        reg = z_encoder.reg * std_X
 
     return pobj, times, D_hat, z_hat, reg
 

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -298,9 +298,7 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
         if greedy and ii % n_iter_by_atom == 0 and \
                 z_encoder.D_hat.shape[0] < n_atoms:
             # add a new atom every n_iter_by_atom iterations
-            new_atom = d_solver.get_max_error_dict(z_encoder)[0]
-            # XXX what should happen here when using DiCoDiLe?
-            z_encoder.add_one_atom(new_atom)
+            d_solver.add_one_atom(z_encoder)
 
         if lmbd_max not in ['fixed', 'scaled']:
             reg_ = reg * get_lambda_max(X, z_encoder.D_hat)

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -108,7 +108,7 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
     D_init : str or array, shape (n_atoms, n_channels + n_times_atoms) or \
                            shape (n_atoms, n_channels, n_times_atom)
         The initial atoms or an initialization scheme in {'kmeans' | 'ssa' |
-        'chunk' | 'random'}.
+        'chunk' | 'random' | 'greedy'}.
     D_init_params : dict
         Dictionnary of parameters for the kmeans init method.
     unbiased_z_hat : boolean
@@ -293,8 +293,8 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
             z_encoder.update_reg(lmbd_max == 'shared')
 
             if verbose > 5:
-                print('[{}] lambda = {:.3e}'.format(
-                    name, np.mean(z_encoder.reg)))
+                print('[{}] lambda = {:.3e}'.format(name,
+                                                    np.mean(z_encoder.reg)))
 
         # Compute z update
         start = time.time()
@@ -379,8 +379,8 @@ def _online_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
             z_encoder.update_reg(lmbd_max == 'shared')
 
             if verbose > 5:
-                print('[{}] lambda = {:.3e}'.format(
-                    name, np.mean(z_encoder.reg)))
+                print('[{}] lambda = {:.3e}'.format(name,
+                                                    np.mean(z_encoder.reg)))
 
         # Compute z update
         start = time.time()

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -290,7 +290,7 @@ def _batch_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
         if lmbd_max in ['per_atom', 'shared'] or (
                 lmbd_max == 'scaled' and ii == 0
         ):
-            z_encoder.update_reg()
+            z_encoder.update_reg(lmbd_max == 'per_atom')
 
             if verbose > 5:
                 print('[{}] lambda = {:.3e}'.format(name,
@@ -367,7 +367,7 @@ def _online_learn(z_encoder, d_solver, end_iter_func, n_iter=100,
         if lmbd_max in ['per_atom', 'shared'] or (
                 lmbd_max == 'scaled' and ii == 0
         ):
-            z_encoder.update_reg()
+            z_encoder.update_reg(lmbd_max == 'per_atom')
 
             if verbose > 5:
                 print('[{}] lambda = {:.3e}'.format(name,

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -195,8 +195,11 @@ def learn_d_z_multi(X, n_atoms, n_times_atom, n_iter=60, n_jobs=1,
 
     z_kwargs = dict(verbose=verbose, **solver_z_kwargs)
 
-    with get_z_encoder_for(X, d_solver.D_hat, n_atoms, n_times_atom, n_jobs, solver_z,
-                           z_kwargs, reg, loss, loss_params) as z_encoder:
+    with get_z_encoder_for(
+            X, d_solver.D_hat, n_atoms, n_times_atom, n_jobs,
+            solver_z, z_kwargs, reg, loss, loss_params
+    ) as z_encoder:
+
         if callable(callback):
             callback(z_encoder, [])
 

--- a/alphacsc/online_dictionary_learning.py
+++ b/alphacsc/online_dictionary_learning.py
@@ -122,14 +122,13 @@ class OnlineCDL(ConvolutionalDictionaryLearning):
         self.d_solver = get_solver_d(
             n_channels, self.n_atoms, self.n_times_atom,
             solver_d=self.solver_d, rank1=self.rank1, window=self.window,
+            D_init=self.D_init, D_init_params=self.D_init_params,
             random_state=self.random_state, **self.solver_d_kwargs
         )
 
         # Init dictionary either from D_init or from an heuristic based on the
         # first batch X
-        self._D_hat = self.d_solver.init_dictionary(
-            X, D_init=self.D_init, D_init_params=self.D_init_params
-        )
+        self._D_hat = self.d_solver.init_dictionary(X)
 
         self.reg_ = self.reg
         _lmbd_max = get_lambda_max(X, self._D_hat).max()

--- a/alphacsc/tests/conftest.py
+++ b/alphacsc/tests/conftest.py
@@ -7,7 +7,7 @@ from alphacsc.utils import check_random_state, construct_X_multi
 from alphacsc.utils.compute_constants import compute_ztz, compute_ztX
 from alphacsc.loss_and_gradient import compute_objective
 
-N_TRIALS, N_CHANNELS, N_TIMES = 5, 3, 100
+N_TRIALS, N_CHANNELS, N_TIMES = 2, 3, 100
 N_TIMES_ATOM, N_ATOMS = 6, 4
 
 parametrize_solver_and_constraint = pytest.mark.parametrize(

--- a/alphacsc/tests/conftest.py
+++ b/alphacsc/tests/conftest.py
@@ -31,6 +31,11 @@ def rng():
 
 
 @pytest.fixture
+def n_trials():
+    return N_TRIALS
+
+
+@pytest.fixture
 def X(rng, n_trials):
     return rng.randn(n_trials, N_CHANNELS, N_TIMES)
 

--- a/alphacsc/tests/conftest.py
+++ b/alphacsc/tests/conftest.py
@@ -67,6 +67,9 @@ class MockZEncoder:
     def get_z_hat(self):
         return self.z_hat
 
+    def set_D(self, D):
+        self.D_hat = D
+
     def get_constants(self):
 
         return dict(ztX=self.ztX, ztz=self.ztz, XtX=self.XtX,

--- a/alphacsc/tests/conftest.py
+++ b/alphacsc/tests/conftest.py
@@ -14,16 +14,14 @@ N_TIMES_ATOM, N_ATOMS = 10, 4
 parametrize_solver_and_constraint = pytest.mark.parametrize(
     'rank1, solver_d, uv_constraint',
     [
-        (True, 'auto', 'auto'),
-        (False, 'auto', 'auto'),
-        (False, 'fista', 'auto'),
-        (True, 'joint', 'auto'),
+        (True, 'alternate_adaptive', 'separate'),
+        (True, 'alternate', 'separate'),
         (True, 'joint', 'joint'),
         (True, 'joint', 'separate'),
-        (True, 'fista', 'auto'),
         (True, 'fista', 'joint'),
         (True, 'fista', 'separate'),
-        (True, 'alternate_adaptive', 'separate')
+        (False, 'auto', 'auto'),
+        (False, 'fista', 'auto'),
     ]
 )
 

--- a/alphacsc/tests/test_d_solver.py
+++ b/alphacsc/tests/test_d_solver.py
@@ -282,7 +282,8 @@ def test_init_dictionary_rank1_initial_D_init(X, D_init, solver_d,
 ])
 @pytest.mark.parametrize('loss', ['l2'])
 @pytest.mark.parametrize('window', ['True', 'False'])
-def test_update_D(D_hat, rank1, solver_d, uv_constraint, window, z_encoder, rng):
+def test_update_D(D_hat, rank1, solver_d, uv_constraint, window,
+                  z_encoder, rng):
 
     d_solver = get_solver_d(N_CHANNELS,
                             N_ATOMS,

--- a/alphacsc/tests/test_d_solver.py
+++ b/alphacsc/tests/test_d_solver.py
@@ -349,7 +349,8 @@ def test_update_D(rank1, solver_d, uv_constraint, window, z_encoder, rng):
     (True, 'alternate', 'separate'),
 ])
 @pytest.mark.parametrize('loss', ['dtw', 'whitening'])
-def test_update_D_error(rank1, solver_d, uv_constraint, z_encoder, rng):
+@pytest.mark.parametrize('n_trials', [2])
+def test_update_D_error(X, D_hat, rank1, solver_d, uv_constraint, z_encoder):
 
     d_solver = get_solver_d(N_CHANNELS,
                             N_ATOMS,
@@ -358,6 +359,8 @@ def test_update_D_error(rank1, solver_d, uv_constraint, z_encoder, rng):
                             uv_constraint=uv_constraint,
                             rank1=rank1,
                             max_iter=1000)
+
+    d_solver.init_dictionary(X, D_hat)
 
     with pytest.raises(NotImplementedError):
         d_solver.update_D(z_encoder)

--- a/alphacsc/tests/test_d_solver.py
+++ b/alphacsc/tests/test_d_solver.py
@@ -8,12 +8,79 @@ from alphacsc.tests.conftest import N_TRIALS, N_CHANNELS, N_TIMES_ATOM, N_ATOMS
 from alphacsc.loss_and_gradient import compute_objective
 from alphacsc.utils import construct_X_multi
 from alphacsc.update_d_multi import prox_d, prox_uv
-from alphacsc._d_solver import get_solver_d
+from alphacsc._d_solver import get_solver_d, check_solver_and_constraints
 
 
 @pytest.fixture
 def D_init(rng, shape):
     return rng.randn(*shape)
+
+
+@pytest.mark.parametrize('solver_d', ['auto', 'fista'])
+@pytest.mark.parametrize('uv_constraint', ['auto'])
+def test_check_solver_and_constraints(solver_d, uv_constraint):
+    """Tests for valid values when rank1 is False."""
+
+    solver_d_, uv_constraint_ = check_solver_and_constraints(False, solver_d,
+                                                             uv_constraint)
+
+    assert solver_d_ == 'fista'
+    assert uv_constraint_ == 'auto'
+
+
+@pytest.mark.parametrize('solver_d', ['auto', 'fista'])
+@pytest.mark.parametrize('uv_constraint', ['joint', 'separate'])
+def test_check_solver_and_constraints_error(solver_d, uv_constraint):
+    """Tests for the case rank1 is False and params are not compatible."""
+
+    with pytest.raises(AssertionError,
+                       match="If rank1 is False, uv_constraint should be*"):
+
+        check_solver_and_constraints(False, solver_d, uv_constraint)
+
+
+@pytest.mark.parametrize('solver_d', ['auto', 'alternate',
+                                      'alternate_adaptive'])
+@pytest.mark.parametrize('uv_constraint', ['auto', 'separate'])
+def test_check_solver_and_constraints_rank1_alternate(solver_d, uv_constraint):
+    """Tests for valid values when solver is alternate and rank1 is True."""
+
+    solver_d_, uv_constraint_ = check_solver_and_constraints(True, solver_d,
+                                                             uv_constraint)
+
+    if solver_d == 'auto':
+        solver_d = 'alternate_adaptive'
+
+    assert solver_d_ == solver_d
+    assert uv_constraint_ == 'separate'
+
+
+@pytest.mark.parametrize('solver_d', ['joint', 'fista'])
+@pytest.mark.parametrize('uv_constraint', ['auto', 'joint', 'separate'])
+def test_check_solver_and_constraints_rank1(solver_d, uv_constraint):
+    """Tests for valid values when solver_d is either in 'joint' or 'fista' and
+    rank1 is True."""
+
+    solver_d_, uv_constraint_ = check_solver_and_constraints(True, solver_d,
+                                                             uv_constraint)
+
+    if uv_constraint == 'auto':
+        uv_constraint = 'joint'
+
+    assert solver_d_ == solver_d
+    assert uv_constraint_ == uv_constraint
+
+
+@pytest.mark.parametrize('solver_d', ['auto', 'alternate',
+                                      'alternate_adaptive'])
+@pytest.mark.parametrize('uv_constraint', ['joint'])
+def test_check_solver_and_constraints_rank1_error(solver_d, uv_constraint):
+    """Tests for the case when rank1 is True and params are not compatible.
+    """
+    with pytest.raises(AssertionError,
+                       match="solver_d=*"):
+
+        check_solver_and_constraints(True, solver_d, uv_constraint)
 
 
 @pytest.mark.parametrize('rank1, solver_d, uv_constraint', [

--- a/alphacsc/tests/test_d_solver.py
+++ b/alphacsc/tests/test_d_solver.py
@@ -3,7 +3,7 @@ from numpy.testing import assert_allclose
 
 import numpy as np
 
-from alphacsc.tests.conftest import N_TRIALS, N_CHANNELS, N_TIMES_ATOM, N_ATOMS
+from alphacsc.tests.conftest import N_CHANNELS, N_TIMES_ATOM, N_ATOMS
 
 from alphacsc.update_d_multi import prox_d, prox_uv
 from alphacsc._d_solver import get_solver_d, check_solver_and_constraints
@@ -182,7 +182,6 @@ def test_get_solver_d_error_rank1_uv_constraint(solver_d):
     ('alternate_adaptive', 'separate', True, (N_ATOMS, N_CHANNELS+N_TIMES_ATOM)),  # noqa
 ])
 @pytest.mark.parametrize('window', [True, False])
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 @pytest.mark.parametrize('D_init', ['random', 'chunk', 'kmeans', 'ssa'])
 def test_init_dictionary(X, D_init, solver_d, uv_constraint, rank1, shape,
                          window):
@@ -209,7 +208,6 @@ def test_init_dictionary(X, D_init, solver_d, uv_constraint, rank1, shape,
 @pytest.mark.parametrize('uv_constraint', ['auto'])
 @pytest.mark.parametrize('shape', [(N_ATOMS, N_CHANNELS, N_TIMES_ATOM)])
 @pytest.mark.parametrize('window', [True, False])
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 def test_init_dictionary_initial_D_init(X, D_init, solver_d, window,
                                         uv_constraint, shape):
     """Tests if init_dictionary is doing what is expected when rank1 is False and
@@ -242,7 +240,6 @@ def test_init_dictionary_initial_D_init(X, D_init, solver_d, window,
 @pytest.mark.parametrize('solver_d', ['joint', 'fista'])
 @pytest.mark.parametrize('uv_constraint', ['joint', 'separate'])
 @pytest.mark.parametrize('shape', [(N_ATOMS, N_CHANNELS + N_TIMES_ATOM)])
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 def test_init_dictionary_rank1_initial_D_init(X, D_init, solver_d,
                                               uv_constraint, shape):
     """Tests if init_dictionary is doing what is expected  when rank1=True and
@@ -333,7 +330,6 @@ def test_update_D(D_hat, rank1, solver_d, uv_constraint, window,
     (True, 'alternate', 'separate'),
 ])
 @pytest.mark.parametrize('loss', ['dtw', 'whitening'])
-@pytest.mark.parametrize('n_trials', [2])
 def test_update_D_error(X, D_hat, rank1, solver_d, uv_constraint, z_encoder):
 
     d_solver = get_solver_d(N_CHANNELS,
@@ -360,7 +356,6 @@ def test_update_D_error(X, D_hat, rank1, solver_d, uv_constraint, z_encoder):
     (True, 'alternate', 'separate'),
 ])
 @pytest.mark.parametrize('window', [True, False])
-@pytest.mark.parametrize('n_trials', [2])
 def test_add_one_atom(X, rank1, solver_d, uv_constraint, window):
     """Tests valid values."""
 

--- a/alphacsc/tests/test_d_solver.py
+++ b/alphacsc/tests/test_d_solver.py
@@ -256,7 +256,7 @@ def test_init_dictionary_initial_D_init(X, D_init, solver_d, window,
                             solver_d=solver_d,
                             uv_constraint=uv_constraint,
                             rank1=False,
-                            window=False,
+                            window=window,
                             random_state=42)
 
     assert d_solver is not None

--- a/alphacsc/tests/test_init_d.py
+++ b/alphacsc/tests/test_init_d.py
@@ -6,7 +6,6 @@ from numpy.testing import assert_allclose
 
 from alphacsc.init_dict import init_dictionary
 from alphacsc.update_d_multi import prox_uv, prox_d
-from alphacsc.update_d_multi import check_solver_and_constraints
 from alphacsc.learn_d_z_multi import learn_d_z_multi
 from alphacsc.utils import check_random_state
 
@@ -18,13 +17,9 @@ def test_init_array(rank1, solver_d, uv_constraint):
     n_trials, n_channels, n_times = 5, 3, 100
     n_times_atom, n_atoms = 10, 4
 
-    _, uv_constraint_ = check_solver_and_constraints(
-        rank1, solver_d, uv_constraint
-    )
-
     if rank1:
         expected_shape = (n_atoms, n_channels + n_times_atom)
-        prox = functools.partial(prox_uv, uv_constraint=uv_constraint_,
+        prox = functools.partial(prox_uv, uv_constraint=uv_constraint,
                                  n_channels=n_channels)
     else:
         expected_shape = (n_atoms, n_channels, n_times_atom)
@@ -35,7 +30,7 @@ def test_init_array(rank1, solver_d, uv_constraint):
     # Test that init_dictionary is doing what we expect for D_init array
     D_init = np.random.randn(*expected_shape)
     D_hat = init_dictionary(X, n_atoms, n_times_atom, D_init=D_init,
-                            rank1=rank1, uv_constraint=uv_constraint_)
+                            rank1=rank1, uv_constraint=uv_constraint)
 
     D_init = prox(D_init)
     assert_allclose(D_hat, D_init)
@@ -58,13 +53,9 @@ def test_init_random(rank1, solver_d, uv_constraint):
     n_trials, n_channels, n_times = 5, 3, 100
     n_times_atom, n_atoms = 10, 4
 
-    _, uv_constraint_ = check_solver_and_constraints(
-        rank1, solver_d, uv_constraint
-    )
-
     if rank1:
         expected_shape = (n_atoms, n_channels + n_times_atom)
-        prox = functools.partial(prox_uv, uv_constraint=uv_constraint_,
+        prox = functools.partial(prox_uv, uv_constraint=uv_constraint,
                                  n_channels=n_channels)
     else:
         expected_shape = (n_atoms, n_channels, n_times_atom)
@@ -75,7 +66,7 @@ def test_init_random(rank1, solver_d, uv_constraint):
     # Test that init_dictionary is doing what we expect for D_init random
     random_state = 42
     D_hat = init_dictionary(X, n_atoms, n_times_atom, D_init='random',
-                            rank1=rank1, uv_constraint=uv_constraint_,
+                            rank1=rank1, uv_constraint=uv_constraint,
                             random_state=random_state)
     rng = check_random_state(random_state)
 

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -1,4 +1,3 @@
-from alphacsc.update_d_multi import check_solver_and_constraints
 import pytest
 import numpy as np
 
@@ -13,7 +12,20 @@ from alphacsc.tests.conftest import parametrize_solver_and_constraint
 
 @pytest.mark.parametrize('window', [False, True])
 @pytest.mark.parametrize('loss', ['l2', 'dtw', 'whitening'])
-@parametrize_solver_and_constraint
+@pytest.mark.parametrize('rank1, solver_d, uv_constraint',
+                         [
+                             (True, 'auto', 'auto'),
+                             (False, 'auto', 'auto'),
+                             (False, 'fista', 'auto'),
+                             (True, 'joint', 'auto'),
+                             (True, 'joint', 'joint'),
+                             (True, 'joint', 'separate'),
+                             (True, 'fista', 'auto'),
+                             (True, 'fista', 'joint'),
+                             (True, 'fista', 'separate'),
+                             (True, 'alternate_adaptive', 'separate')
+                         ]
+                         )
 def test_learn_d_z_multi(loss, rank1, solver_d, uv_constraint, window):
     # smoke test for learn_d_z_multi
     n_trials, n_channels, n_times = 2, 3, 30
@@ -103,12 +115,8 @@ def test_window(rank1, solver_d, uv_constraint):
     rng = check_random_state(42)
     X = rng.randn(n_trials, n_channels, n_times)
 
-    *_, uv_constraint_ = check_solver_and_constraints(
-        rank1, solver_d, uv_constraint
-    )
-
     D_init = init_dictionary(X, n_atoms, n_times_atom, rank1=rank1,
-                             uv_constraint=uv_constraint_, random_state=0,
+                             uv_constraint=uv_constraint, random_state=0,
                              window=False)
 
     kwargs = dict(X=X, n_atoms=n_atoms, n_times_atom=n_times_atom, verbose=0,
@@ -117,7 +125,7 @@ def test_window(rank1, solver_d, uv_constraint):
     res_False = learn_d_z_multi(window=False, **kwargs)
 
     D_init = init_dictionary(X, n_atoms, n_times_atom, rank1=rank1,
-                             uv_constraint=uv_constraint_, random_state=0,
+                             uv_constraint=uv_constraint, random_state=0,
                              window=True)
 
     kwargs = dict(X=X, n_atoms=n_atoms, n_times_atom=n_times_atom, verbose=0,

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -46,7 +46,8 @@ def test_learn_d_z_multi(X, loss, rank1, solver_d, uv_constraint, window,
         uv_constraint)
 
     try:
-        assert np.sum(np.diff(pobj) > 1e-13) == 0, msg
+        if lmbd_max != 'shared' or 'per_atom':
+            assert np.sum(np.diff(pobj) > 1e-13) == 0, msg
     except AssertionError:
         import matplotlib.pyplot as plt
         plt.semilogy(pobj - np.min(pobj) + 1e-6)

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -9,7 +9,7 @@ from alphacsc.init_dict import init_dictionary
 
 from alphacsc.tests.conftest import parametrize_solver_and_constraint
 
-from conftest import N_ATOMS, N_TIMES, N_TIMES_ATOM, N_CHANNELS, N_TRIALS
+from conftest import N_ATOMS, N_TIMES, N_TIMES_ATOM, N_CHANNELS
 
 
 @pytest.mark.parametrize('window', [False, True])
@@ -29,7 +29,6 @@ from conftest import N_ATOMS, N_TIMES, N_TIMES_ATOM, N_CHANNELS, N_TRIALS
                          ]
                          )
 @pytest.mark.parametrize('lmbd_max', ['fixed', 'scaled', 'shared', 'per_atom'])
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 def test_learn_d_z_multi(X, loss, rank1, solver_d, uv_constraint, window,
                          lmbd_max):
     # smoke test for learn_d_z_multi
@@ -60,7 +59,6 @@ def test_learn_d_z_multi(X, loss, rank1, solver_d, uv_constraint, window,
 @pytest.mark.parametrize('loss', ['dtw', 'whitening'])
 @pytest.mark.parametrize('rank1, solver_d, uv_constraint', [
     (True, 'alternate', 'separate')])
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 def test_learn_d_z_multi_error(X, loss, rank1, solver_d, uv_constraint,
                                window):
     # smoke test for learn_d_z_multi
@@ -102,7 +100,6 @@ def test_learn_d_z_multi_dicodile(X, window):
 
 
 @parametrize_solver_and_constraint
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 def test_window(X, rank1, solver_d, uv_constraint):
     # Smoke test that the parameter window does something
 
@@ -128,7 +125,6 @@ def test_window(X, rank1, solver_d, uv_constraint):
     assert not np.allclose(res_False[2], res_True[2])
 
 
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 def test_online_learning(X, n_trials):
     # smoke test for learn_d_z_multi
 
@@ -147,7 +143,6 @@ def test_online_learning(X, n_trials):
 
 @pytest.mark.parametrize('klass', [BatchCDL, OnlineCDL, GreedyCDL])
 @parametrize_solver_and_constraint
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 def test_transformers(X, klass, rank1, solver_d, uv_constraint, n_trials):
     # smoke test for transformer classes
 
@@ -178,7 +173,6 @@ def test_transformers(X, klass, rank1, solver_d, uv_constraint, n_trials):
 
 
 @pytest.mark.parametrize('solver_z', ['l-bfgs', 'lgcd'])
-@pytest.mark.parametrize('n_trials', [N_TRIALS])
 def test_unbiased_z_hat(X, solver_z):
 
     loss_params = dict(gamma=1, sakoe_chiba_band=10, ordar=10)

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -9,6 +9,8 @@ from alphacsc.init_dict import init_dictionary
 
 from alphacsc.tests.conftest import parametrize_solver_and_constraint
 
+from conftest import N_ATOMS, N_TIMES, N_TIMES_ATOM, N_CHANNELS, N_TRIALS
+
 
 @pytest.mark.parametrize('window', [False, True])
 @pytest.mark.parametrize('loss', ['l2', 'dtw', 'whitening'])
@@ -26,18 +28,17 @@ from alphacsc.tests.conftest import parametrize_solver_and_constraint
                              (True, 'alternate_adaptive', 'separate')
                          ]
                          )
-def test_learn_d_z_multi(loss, rank1, solver_d, uv_constraint, window):
+@pytest.mark.parametrize('lmbd_max', ['fixed', 'scaled', 'shared', 'per_atom'])
+@pytest.mark.parametrize('n_trials', [N_TRIALS])
+def test_learn_d_z_multi(X, loss, rank1, solver_d, uv_constraint, window,
+                         lmbd_max):
     # smoke test for learn_d_z_multi
-    n_trials, n_channels, n_times = 2, 3, 30
-    n_times_atom, n_atoms = 6, 4
 
     loss_params = dict(gamma=1, sakoe_chiba_band=10, ordar=10)
 
-    rng = check_random_state(42)
-    X = rng.randn(n_trials, n_channels, n_times)
     pobj, times, uv_hat, z_hat, reg = learn_d_z_multi(
-        X, n_atoms, n_times_atom, uv_constraint=uv_constraint, rank1=rank1,
-        solver_d=solver_d, random_state=0,
+        X, N_ATOMS, N_TIMES_ATOM, uv_constraint=uv_constraint, rank1=rank1,
+        solver_d=solver_d, random_state=0, lmbd_max=lmbd_max,
         n_iter=30, eps=-np.inf, solver_z='l-bfgs', window=window,
         verbose=0, loss=loss, loss_params=loss_params)
 
@@ -58,19 +59,16 @@ def test_learn_d_z_multi(loss, rank1, solver_d, uv_constraint, window):
 @pytest.mark.parametrize('loss', ['dtw', 'whitening'])
 @pytest.mark.parametrize('rank1, solver_d, uv_constraint', [
     (True, 'alternate', 'separate')])
-def test_learn_d_z_multi_error(loss, rank1, solver_d, uv_constraint, window):
+@pytest.mark.parametrize('n_trials', [N_TRIALS])
+def test_learn_d_z_multi_error(X, loss, rank1, solver_d, uv_constraint,
+                               window):
     # smoke test for learn_d_z_multi
-    n_trials, n_channels, n_times = 2, 3, 30
-    n_times_atom, n_atoms = 6, 4
 
     loss_params = dict(gamma=1, sakoe_chiba_band=10, ordar=10)
 
-    rng = check_random_state(42)
-    X = rng.randn(n_trials, n_channels, n_times)
-
     with pytest.raises(NotImplementedError):
         pobj, times, uv_hat, z_hat, reg = learn_d_z_multi(
-            X, n_atoms, n_times_atom, uv_constraint=uv_constraint, rank1=rank1,
+            X, N_ATOMS, N_TIMES_ATOM, uv_constraint=uv_constraint, rank1=rank1,
             solver_d=solver_d, random_state=0,
             n_iter=30, eps=-np.inf, solver_z='l-bfgs', window=window,
             verbose=0, loss=loss, loss_params=loss_params
@@ -79,17 +77,13 @@ def test_learn_d_z_multi_error(loss, rank1, solver_d, uv_constraint, window):
 
 @pytest.mark.parametrize('window', [False, True])
 # TODO expand params when DiCoDiLe is rank-1-capable
-def test_learn_d_z_multi_dicodile(window):
+@pytest.mark.parametrize('n_trials', [1])
+def test_learn_d_z_multi_dicodile(X, window):
     pytest.importorskip('dicodile')
     # smoke test for learn_d_z_multi
-    # XXX For DiCoDiLe, n_trials cannot be >1
-    n_trials, n_channels, n_times = 1, 3, 30
-    n_times_atom, n_atoms = 6, 4
 
-    rng = check_random_state(42)
-    X = rng.randn(n_trials, n_channels, n_times)
     pobj, times, uv_hat, z_hat, reg = learn_d_z_multi(
-        X, n_atoms, n_times_atom, uv_constraint='auto', rank1=False,
+        X, N_ATOMS, N_TIMES_ATOM, uv_constraint='auto', rank1=False,
         solver_d='auto', random_state=0,
         n_iter=30, eps=-np.inf, solver_z='dicodile', window=window,
         verbose=0, loss='l2', loss_params=None)
@@ -107,49 +101,43 @@ def test_learn_d_z_multi_dicodile(window):
 
 
 @parametrize_solver_and_constraint
-def test_window(rank1, solver_d, uv_constraint):
+@pytest.mark.parametrize('n_trials', [N_TRIALS])
+def test_window(X, rank1, solver_d, uv_constraint):
     # Smoke test that the parameter window does something
-    n_trials, n_channels, n_times = 2, 3, 100
-    n_times_atom, n_atoms = 10, 4
 
-    rng = check_random_state(42)
-    X = rng.randn(n_trials, n_channels, n_times)
-
-    D_init = init_dictionary(X, n_atoms, n_times_atom, rank1=rank1,
+    D_init = init_dictionary(X, N_ATOMS, N_TIMES_ATOM, rank1=rank1,
                              uv_constraint=uv_constraint, random_state=0,
                              window=False)
 
-    kwargs = dict(X=X, n_atoms=n_atoms, n_times_atom=n_times_atom, verbose=0,
+    kwargs = dict(X=X, n_atoms=N_ATOMS, n_times_atom=N_TIMES_ATOM, verbose=0,
                   uv_constraint=uv_constraint, solver_d=solver_d, rank1=rank1,
                   random_state=0, n_iter=1, solver_z='l-bfgs', D_init=D_init)
     res_False = learn_d_z_multi(window=False, **kwargs)
 
-    D_init = init_dictionary(X, n_atoms, n_times_atom, rank1=rank1,
+    D_init = init_dictionary(X, N_ATOMS, N_TIMES_ATOM, rank1=rank1,
                              uv_constraint=uv_constraint, random_state=0,
                              window=True)
 
-    kwargs = dict(X=X, n_atoms=n_atoms, n_times_atom=n_times_atom, verbose=0,
+    kwargs = dict(X=X, n_atoms=N_ATOMS, n_times_atom=N_TIMES_ATOM, verbose=0,
                   uv_constraint=uv_constraint, solver_d=solver_d, rank1=rank1,
                   random_state=0, n_iter=1, solver_z='l-bfgs', D_init=D_init)
+
     res_True = learn_d_z_multi(window=True, **kwargs)
 
     assert not np.allclose(res_False[2], res_True[2])
 
 
-def test_online_learning():
+@pytest.mark.parametrize('n_trials', [N_TRIALS])
+def test_online_learning(X, n_trials):
     # smoke test for learn_d_z_multi
-    n_trials, n_channels, n_times = 2, 3, 100
-    n_times_atom, n_atoms = 10, 4
 
-    rng = check_random_state(42)
-    X = rng.randn(n_trials, n_channels, n_times)
     pobj_0, _, _, _, _ = learn_d_z_multi(
-        X, n_atoms, n_times_atom, uv_constraint="separate", solver_d="joint",
+        X, N_ATOMS, N_TIMES_ATOM, uv_constraint="separate", solver_d="joint",
         random_state=0, n_iter=30, solver_z='l-bfgs', algorithm="batch",
         loss='l2')
 
     pobj_1, _, _, _, _ = learn_d_z_multi(
-        X, n_atoms, n_times_atom, uv_constraint="separate", solver_d="joint",
+        X, N_ATOMS, N_TIMES_ATOM, uv_constraint="separate", solver_d="joint",
         random_state=0, n_iter=30, solver_z='l-bfgs', algorithm="online",
         algorithm_params=dict(batch_size=n_trials, alpha=0), loss='l2')
 
@@ -158,10 +146,9 @@ def test_online_learning():
 
 @pytest.mark.parametrize('klass', [BatchCDL, OnlineCDL, GreedyCDL])
 @parametrize_solver_and_constraint
-def test_transformers(klass, rank1, solver_d, uv_constraint):
+@pytest.mark.parametrize('n_trials', [N_TRIALS])
+def test_transformers(X, klass, rank1, solver_d, uv_constraint, n_trials):
     # smoke test for transformer classes
-    n_trials, n_channels, n_times = 2, 3, 100
-    n_times_atom, n_atoms = 10, 4
 
     if klass == OnlineCDL:
         kwargs = dict(batch_selection='cyclic')
@@ -169,8 +156,8 @@ def test_transformers(klass, rank1, solver_d, uv_constraint):
         kwargs = dict()
 
     rng = check_random_state(42)
-    X = rng.randn(n_trials, n_channels, n_times)
-    cdl = klass(n_atoms, n_times_atom, uv_constraint=uv_constraint,
+    X = rng.randn(n_trials, N_CHANNELS, N_TIMES)
+    cdl = klass(N_ATOMS, N_TIMES_ATOM, uv_constraint=uv_constraint,
                 rank1=rank1, solver_d=solver_d, random_state=0, n_iter=10,
                 eps=-np.inf, solver_z='l-bfgs', window=True, verbose=0,
                 **kwargs)
@@ -190,23 +177,19 @@ def test_transformers(klass, rank1, solver_d, uv_constraint):
 
 
 @pytest.mark.parametrize('solver_z', ['l-bfgs', 'lgcd'])
-def test_unbiased_z_hat(solver_z):
-    n_trials, n_channels, n_times = 2, 3, 30
-    n_times_atom, n_atoms = 6, 4
+@pytest.mark.parametrize('n_trials', [N_TRIALS])
+def test_unbiased_z_hat(X, solver_z):
 
     loss_params = dict(gamma=1, sakoe_chiba_band=10, ordar=10)
 
-    rng = check_random_state(42)
-    X = rng.randn(n_trials, n_channels, n_times)
-
     _, _, _, z_hat, _ = learn_d_z_multi(
-        X, n_atoms, n_times_atom, uv_constraint='auto', rank1=False,
+        X, N_ATOMS, N_TIMES_ATOM, uv_constraint='auto', rank1=False,
         solver_d='auto', random_state=0, unbiased_z_hat=False,
         n_iter=1, eps=-np.inf, solver_z=solver_z, window=False,
         verbose=0, loss='l2', loss_params=loss_params)
 
     _, _, _, z_hat_unbiased, _ = learn_d_z_multi(
-        X, n_atoms, n_times_atom, uv_constraint='auto', rank1=False,
+        X, N_ATOMS, N_TIMES_ATOM, uv_constraint='auto', rank1=False,
         solver_d='auto', random_state=0, unbiased_z_hat=True,
         n_iter=1, eps=-np.inf, solver_z=solver_z, window=False,
         verbose=0, loss='l2', loss_params=loss_params)

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -45,7 +45,7 @@ def test_learn_d_z_multi(X, loss, rank1, solver_d, uv_constraint, window,
         uv_constraint)
 
     try:
-        if lmbd_max != 'shared' or 'per_atom':
+        if lmbd_max != 'shared' and lmbd_max != 'per_atom':
             assert np.sum(np.diff(pobj) > 1e-13) == 0, msg
     except AssertionError:
         import matplotlib.pyplot as plt

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -157,7 +157,8 @@ def test_online_learning():
 
 
 @pytest.mark.parametrize('klass', [BatchCDL, OnlineCDL, GreedyCDL])
-def test_transformers(klass):
+@parametrize_solver_and_constraint
+def test_transformers(klass, rank1, solver_d, uv_constraint):
     # smoke test for transformer classes
     n_trials, n_channels, n_times = 2, 3, 100
     n_times_atom, n_atoms = 10, 4

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -170,8 +170,8 @@ def test_transformers(klass, rank1, solver_d, uv_constraint):
 
     rng = check_random_state(42)
     X = rng.randn(n_trials, n_channels, n_times)
-    cdl = klass(n_atoms, n_times_atom, uv_constraint='separate', rank1=True,
-                solver_d='alternate_adaptive', random_state=0, n_iter=10,
+    cdl = klass(n_atoms, n_times_atom, uv_constraint=uv_constraint,
+                rank1=rank1, solver_d=solver_d, random_state=0, n_iter=10,
                 eps=-np.inf, solver_z='l-bfgs', window=True, verbose=0,
                 **kwargs)
     cdl.fit(X)

--- a/alphacsc/tests/test_update_d_multi.py
+++ b/alphacsc/tests/test_update_d_multi.py
@@ -5,79 +5,11 @@ from scipy import optimize, signal
 from alphacsc.loss_and_gradient import compute_objective
 from alphacsc.loss_and_gradient import gradient_d, gradient_uv
 from alphacsc.update_d_multi import _get_d_update_constants
-from alphacsc.update_d_multi import check_solver_and_constraints
 from alphacsc.utils.whitening import whitening
 from alphacsc.utils import construct_X_multi
 
 
 DEBUG = True
-
-
-@pytest.mark.parametrize('solver_d', ['auto', 'fista'])
-@pytest.mark.parametrize('uv_constraint', ['auto'])
-def test_check_solver_and_constraints(solver_d, uv_constraint):
-    """Tests for valid values when rank1 is False."""
-
-    solver_d_, uv_constraint_ = check_solver_and_constraints(False, solver_d,
-                                                             uv_constraint)
-
-    assert solver_d_ == 'fista'
-    assert uv_constraint_ == 'auto'
-
-
-@pytest.mark.parametrize('solver_d', ['auto', 'fista'])
-@pytest.mark.parametrize('uv_constraint', ['joint', 'separate'])
-def test_check_solver_and_constraints_error(solver_d, uv_constraint):
-    """Tests for the case rank1 is False and params are not compatible."""
-
-    with pytest.raises(AssertionError,
-                       match="If rank1 is False, uv_constraint should be*"):
-
-        check_solver_and_constraints(False, solver_d, uv_constraint)
-
-
-@pytest.mark.parametrize('solver_d', ['auto', 'alternate',
-                                      'alternate_adaptive'])
-@pytest.mark.parametrize('uv_constraint', ['auto', 'separate'])
-def test_check_solver_and_constraints_rank1_alternate(solver_d, uv_constraint):
-    """Tests for valid values when solver is alternate and rank1 is True."""
-
-    solver_d_, uv_constraint_ = check_solver_and_constraints(True, solver_d,
-                                                             uv_constraint)
-
-    if solver_d == 'auto':
-        solver_d = 'alternate_adaptive'
-
-    assert solver_d_ == solver_d
-    assert uv_constraint_ == 'separate'
-
-
-@pytest.mark.parametrize('solver_d', ['joint', 'fista'])
-@pytest.mark.parametrize('uv_constraint', ['auto', 'joint', 'separate'])
-def test_check_solver_and_constraints_rank1(solver_d, uv_constraint):
-    """Tests for valid values when solver_d is either in 'joint' or 'fista' and
-    rank1 is True."""
-
-    solver_d_, uv_constraint_ = check_solver_and_constraints(True, solver_d,
-                                                             uv_constraint)
-
-    if uv_constraint == 'auto':
-        uv_constraint = 'joint'
-
-    assert solver_d_ == solver_d
-    assert uv_constraint_ == uv_constraint
-
-
-@pytest.mark.parametrize('solver_d', ['auto', 'alternate',
-                                      'alternate_adaptive'])
-@pytest.mark.parametrize('uv_constraint', ['joint'])
-def test_check_solver_and_constraints_rank1_error(solver_d, uv_constraint):
-    """Tests for the case when rank1 is True and params are not compatible.
-    """
-    with pytest.raises(AssertionError,
-                       match="solver_d=*"):
-
-        check_solver_and_constraints(True, solver_d, uv_constraint)
 
 
 def test_simple():

--- a/alphacsc/tests/test_z_encoder.py
+++ b/alphacsc/tests/test_z_encoder.py
@@ -373,19 +373,3 @@ def test_get_sufficient_statistics_partial_error(X, D_hat):
     with pytest.raises(AssertionError,
                        match="compute_z_partial should be called.*"):
         z_encoder.get_sufficient_statistics_partial()
-
-
-@pytest.mark.parametrize('n_trials', [2])
-@pytest.mark.parametrize('rank1', [True])
-def test_add_one_atom(X, D_hat):
-    """Test for valid values."""
-
-    with get_z_encoder_for(X=X,
-                           D_hat=D_hat,
-                           n_atoms=N_ATOMS,
-                           n_times_atom=N_TIMES_ATOM,
-                           n_jobs=2) as z_encoder:
-        new_atom = np.random.rand(N_CHANNELS + N_TIMES_ATOM)
-        z_encoder.add_one_atom(new_atom)
-        n_atoms_plus_one = z_encoder.D_hat.shape[0]
-        assert n_atoms_plus_one == N_ATOMS + 1

--- a/alphacsc/tests/test_z_encoder.py
+++ b/alphacsc/tests/test_z_encoder.py
@@ -3,22 +3,13 @@ import numpy as np
 import pytest
 
 from alphacsc._z_encoder import get_z_encoder_for
-from alphacsc.init_dict import init_dictionary
 from alphacsc.loss_and_gradient import compute_objective
 from alphacsc.utils import construct_X_multi
 from alphacsc.utils.compute_constants import compute_ztz, compute_ztX
 
+from conftest import N_ATOMS, N_TIMES_ATOM
+
 N_CHANNELS, N_TIMES = 3, 30
-N_TIMES_ATOM, N_ATOMS = 6, 4
-
-
-@pytest.fixture
-def D_hat(X, rank1):
-    return init_dictionary(X,
-                           N_ATOMS,
-                           N_TIMES_ATOM,
-                           random_state=0,
-                           rank1=rank1)
 
 
 @pytest.fixture
@@ -151,7 +142,6 @@ def test_get_encoder_for_error_solver_kwargs(X, D_hat):
                           n_jobs=2)
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('rank1', [True])
 @pytest.mark.parametrize('X_error', [None, np.zeros([2, N_CHANNELS])])
 def test_get_encoder_for_error_X(X_error, D_hat):

--- a/alphacsc/tests/test_z_encoder.py
+++ b/alphacsc/tests/test_z_encoder.py
@@ -7,9 +7,7 @@ from alphacsc.loss_and_gradient import compute_objective
 from alphacsc.utils import construct_X_multi
 from alphacsc.utils.compute_constants import compute_ztz, compute_ztX
 
-from conftest import N_ATOMS, N_TIMES_ATOM
-
-N_CHANNELS, N_TIMES = 3, 30
+from conftest import N_ATOMS, N_TIMES_ATOM, N_CHANNELS
 
 
 @pytest.fixture

--- a/alphacsc/tests/test_z_encoder.py
+++ b/alphacsc/tests/test_z_encoder.py
@@ -110,7 +110,6 @@ def test_get_encoder_for_dicodile_error_rank1(X, D_hat, requires_dicodile):
                           n_jobs=2)
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('rank1', [True])
 @pytest.mark.parametrize('solver', [None, 'other'])
 def test_get_encoder_for_error_solver(X, D_hat,  solver):
@@ -126,7 +125,6 @@ def test_get_encoder_for_error_solver(X, D_hat,  solver):
                           n_jobs=2)
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('rank1', [True])
 def test_get_encoder_for_error_solver_kwargs(X, D_hat):
     """Tests for invalid value of `solver_kwargs`."""
@@ -154,7 +152,6 @@ def test_get_encoder_for_error_X(X_error, D_hat):
                           n_jobs=2)
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('D_init', [None, np.zeros(2)])
 def test_get_encoder_for_error_D_hat(X, D_init):
     """Tests for invalid values of `D_hat`."""
@@ -168,7 +165,6 @@ def test_get_encoder_for_error_D_hat(X, D_init):
                           n_jobs=2)
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('rank1', [True])
 def test_get_encoder_for_error_reg(X, D_hat):
     """Tests for invalid value of `reg`."""
@@ -199,7 +195,6 @@ def test_get_encoder_for_error_loss(X, D_hat,  loss):
                           n_jobs=2)
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('rank1', [True])
 def test_get_encoder_for_error_loss_params(X, D_hat):
     """Tests for invalid value of `loss_params`."""
@@ -278,7 +273,6 @@ def test_compute_z(solver, X, D_hat, requires_dicodile):
         assert z_encoder.get_z_hat().any()
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('rank1', [True])
 def test_compute_z_partial(X, D_hat, n_trials, rng):
     """Test for valid values."""
@@ -338,7 +332,6 @@ def test_get_sufficient_statistics_error(solver, X, D_hat,
         z_encoder.get_sufficient_statistics()
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('rank1', [True])
 def test_get_sufficient_statistics_partial(X, D_hat, n_trials, rng):
     """Test for valid values."""
@@ -356,7 +349,6 @@ def test_get_sufficient_statistics_partial(X, D_hat, n_trials, rng):
     assert ztz_i0 is not None and ztX_i0 is not None
 
 
-@pytest.mark.parametrize('n_trials', [2])
 @pytest.mark.parametrize('rank1', [True])
 def test_get_sufficient_statistics_partial_error(X, D_hat):
     """Test for invalid call to function."""

--- a/alphacsc/update_d_multi.py
+++ b/alphacsc/update_d_multi.py
@@ -13,61 +13,6 @@ def squeeze_all_except_one(X, axis=0):
     return X.squeeze(axis=squeeze_axis)
 
 
-def check_solver_and_constraints(rank1, solver_d, uv_constraint):
-    """Checks if solver_d and uv_constraint are compatible depending on
-    rank1 value.
-
-    - If rank1 is False, solver_d should be 'fista' and uv_constraint should be
-    'auto'.
-    - If rank1 is True;
-       - If solver_d is either 'alternate' or 'alternate_adaptive',
-         uv_constraint should be 'separate'.
-       - If solver_d is either 'joint' or 'fista', uv_constraint should be
-         'joint'.
-
-    Parameters
-    ----------
-    rank1: boolean
-        If set to True, learn rank 1 dictionary atoms.
-    solver_d : str in {'alternate' | 'alternate_adaptive' | 'fista' | 'joint' |
-    'auto'}
-        The solver to use for the d update.
-        - If rank1 is False, only option is 'fista'
-        - If rank1 is True, options are 'alternate', 'alternate_adaptive'
-          (default) or 'joint'
-    uv_constraint : str in {'joint' | 'separate' | 'auto'}
-        The kind of norm constraint on the atoms if using rank1=True.
-        If 'joint', the constraint is norm_2([u, v]) <= 1
-        If 'separate', the constraint is norm_2(u) <= 1 and norm_2(v) <= 1
-        If rank1 is False, then uv_constraint must be 'auto'.
-    """
-
-    if rank1:
-        if solver_d == 'auto':
-            solver_d = 'alternate_adaptive'
-        if 'alternate' in solver_d:
-            if uv_constraint == 'auto':
-                uv_constraint = 'separate'
-            else:
-                assert uv_constraint == 'separate', (
-                    "solver_d='alternate*' should be used with "
-                    f"uv_constraint='separate'. Got '{uv_constraint}'."
-                )
-        elif uv_constraint == 'auto' and solver_d in ['joint', 'fista']:
-            uv_constraint = 'joint'
-    else:
-        assert solver_d in ['auto', 'fista'], (
-            f"solver_d should be auto or fista. Got solver_d='{solver_d}'."
-        )
-        assert solver_d in ['auto', 'fista'] and uv_constraint == 'auto', (
-            "If rank1 is False, uv_constraint should be 'auto' "
-            f"and solver_d should be auto or fista. Got solver_d='{solver_d}' "
-            f"and uv_constraint='{uv_constraint}'."
-        )
-        solver_d = 'fista'
-    return solver_d, uv_constraint
-
-
 def prox_uv(uv, uv_constraint='joint', n_channels=None, return_norm=False):
     if uv_constraint == 'joint':
         norm_uv = np.maximum(1, np.linalg.norm(uv, axis=1, keepdims=True))

--- a/alphacsc/utils/dictionary.py
+++ b/alphacsc/utils/dictionary.py
@@ -116,7 +116,7 @@ class NoWindow():
     def simple_window(self, d):
         return d
 
-    def simple_remove_window(self, d):
+    def remove_simple_window(self, d):
         return d
 
 
@@ -138,7 +138,7 @@ class UVWindower(NoWindow):
     def simple_window(self, d):
         return d * self.tukey_window
 
-    def simple_remove_window(self, d):
+    def remove_simple_window(self, d):
         return d / self.tukey_window
 
 

--- a/alphacsc/utils/dictionary.py
+++ b/alphacsc/utils/dictionary.py
@@ -144,7 +144,6 @@ class UVWindower(NoWindow):
 
 class SimpleWindower(NoWindow):
     def __init__(self, n_times_atom):
-        print(f"initialized {n_times_atom}")
         self.tukey_window = tukey_window(n_times_atom)[None, None, :]
 
     def window(self, d):

--- a/alphacsc/utils/dictionary.py
+++ b/alphacsc/utils/dictionary.py
@@ -110,13 +110,13 @@ class NoWindow():
     def window(self, d):
         return d
 
-    def dewindow(self, d):
+    def remove_window(self, d):
         return d
 
     def simple_window(self, d):
         return d
 
-    def simple_dewindow(self, d):
+    def simple_remove_window(self, d):
         return d
 
 
@@ -130,7 +130,7 @@ class UVWindower(NoWindow):
         d[:, self.n_channels:] *= self.tukey_window
         return d
 
-    def dewindow(self, d):
+    def remove_window(self, d):
         d = d.copy()
         d[:, self.n_channels:] /= self.tukey_window
         return d
@@ -138,7 +138,7 @@ class UVWindower(NoWindow):
     def simple_window(self, d):
         return d * self.tukey_window
 
-    def simple_dewindow(self, d):
+    def simple_remove_window(self, d):
         return d / self.tukey_window
 
 
@@ -150,7 +150,7 @@ class SimpleWindower(NoWindow):
     def window(self, d):
         return d * self.tukey_window
 
-    def dewindow(self, d):
+    def remove_window(self, d):
         return d / self.tukey_window
 
 


### PR DESCRIPTION
Changes dictionary initialization using `DictGenerator` and `Rank1DictGenerator` that exploits strategies depending on the value of `D_init`.

I've first moved `init_dictionary` inside `d_solver`, however it seems like dictionary initialization might be necessary outside of `d_solver` as well. So I created generators that can be set upon initialization in `d_solver` depending on `rank1` status. 

I've put window and prox inside `DictGenerator`.  

This PR also binds `d_solver` to  `n_channels`, `n_atoms`, `n_times_atom`.

In `BaseDictGenerator` `wrap` and `wrap_rank1` should be named appropriately. 