### PR TITLE
MNT remove wheels for 32bit configs

### DIFF
--- a/.github/workflows/upload-to-pypi.yml
+++ b/.github/workflows/upload-to-pypi.yml
@@ -51,7 +51,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           # Disable explicitly python 3.10 and building PyPy wheels
-          CIBW_SKIP: cp310-* pp*
+          CIBW_SKIP: cp310-* pp* cp{38,39,310}-manylinux_i686
           CIBW_PRERELEASE_PYTHONS: False
           # Manually force a version (and avoid building local wheels)
           CIBW_ENVIRONMENT: "SETUPTOOLS_SCM_PRETEND_VERSION=${{ github.event.inputs.overrideVersion }}"


### PR DESCRIPTION
`cibuilwheel` freezes when testing wheels for certain 32-bits configurations. Not sure why but it also happened [here](https://github.com/scikit-learn/scikit-learn/issues/22121#issue-1093198865) and [there](https://github.com/deepcharles/ruptures/pull/225#issuecomment-1015301852).

This PR skips the wheel building process for manylinux_i686 (py38 and 39) which are the problematic configurations.