### PR TITLE
Update release procedure

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,50 @@
 
 This page describes the procedure to release to PyPI.
 
+### Before release
+
+Before each release [switcher.json](doc/_static/switcher.json) file should be
+updated with the latest release version. For example, `the switcher.json` file for
+latest stable release `0.3`:
+
+```json
+[
+  {
+    "name": "dev",
+    "version": "dev",
+    "url": "/dev/"
+  },
+  {
+    "name": "0.3 (stable)",
+    "version": "0.3",
+    "url": "/stable/"
+  }
+]
+```
+becomes:
+
+```json
+[
+  {
+    "name": "dev",
+    "version": "dev",
+    "url": "/dev/"
+  },
+  {
+    "name": "0.3",
+    "version": "0.3",
+    "url": "/0.3/"
+  },
+  {
+    "name": "0.4.0 (stable)",
+    "version": "0.4.0",
+    "url": "/stable/"
+  }
+]
+```
+for release `0.4.0`.
+
+
 ### Automatic procedure
 
 Create a [Github release](https://github.com/alphacsc/alphacsc/releases) with a version tag (e.g. "v1.2.3").

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -5,8 +5,13 @@
     "url": "/dev/"
   },
   {
-    "name": "0.3 (stable)",
+    "name": "0.3",
     "version": "0.3",
+    "url": "/0.3/"
+  },
+  {
+    "name": "0.4.0 (stable)",
+    "version": "0.4.0",
     "url": "/stable/"
   }
 ]


### PR DESCRIPTION
- Updates [switcher.json](https://github.com/alphacsc/alphacsc/blob/master/doc/_static/switcher.json) with new release version.
- Updates [RELEASE.md](https://github.com/alphacsc/alphacsc/blob/master/RELEASE.md) to add `Before release` section.