### PR TITLE
pin sphinx version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ doc =
     pydata-sphinx-theme	
     numpydoc
     sphinx_gallery
+    sphinx==4.5.0
     pactools
     nibabel
 


### PR DESCRIPTION
Pending resolution of https://github.com/sphinx-doc/sphinx/issues/10621, we could pin the sphinx version to 4.5