### PR TITLE
Fix doc generation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -188,13 +188,18 @@ texinfo_documents = [
      'Miscellaneous'),
 ]
 
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'mne': ('http://mne.tools/stable/', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy-1.9.1', None),
+    'scipy': ('http://docs.scipy.org/doc/scipy-0.17.0/reference', None),
+    'mayavi': ('http://docs.enthought.com/mayavi/mayavi', None)
+}
+
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',
     'gallery_dirs': 'auto_examples',
     'reference_url': {
-        'mne': 'http://mne.tools/stable/',
-        'alphacsc': 'http://alphacsc.github.io/',
-        'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
-        'scipy': 'http://docs.scipy.org/doc/scipy-0.17.0/reference',
-        'mayavi': 'http://docs.enthought.com/mayavi/mayavi'}
+        'alphacsc': None
+    }
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,10 +40,10 @@ test =
      pytest-cov
 
 doc =
-    pydata-sphinx-theme	
+    pydata-sphinx-theme	 
     numpydoc
     sphinx_gallery
-    sphinx==4.5.0
+    sphinx
     pactools
     nibabel
 


### PR DESCRIPTION
Fixes doc build problems due to sphinx-gallery `ref_url` section. 

Leaves linking external modules to Sphinx extension [sphinx.ext.intersphinx](https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#module-sphinx.ext.intersphinx).