### PR TITLE
Fix doc generation

### DIFF
--- a/alphacsc/utils/dictionary.py
+++ b/alphacsc/utils/dictionary.py
@@ -11,8 +11,8 @@ def get_D(uv_hat, n_channels):
     n_channels: int
         number of channels in the original multivariate series
 
-    Return
-    ------
+    Returns
+    -------
     D: array (n_atoms, n_channels, n_times_atom)
     """
 
@@ -26,8 +26,8 @@ def get_uv(D):
     ---------
     D: array (n_atoms, n_channels, n_times_atom)
 
-    Return
-    ------
+    Returns
+    -------
     uv: array (n_atoms, n_channels + n_times_atom)
     """
     n_atoms, n_channels, n_times_atom = D.shape

--- a/alphacsc/utils/signal.py
+++ b/alphacsc/utils/signal.py
@@ -40,8 +40,8 @@ def split_signal(X, n_splits=1, apply_window=True):
         reduce the border artifacts by reducing the weights of the chunk
         borders.
 
-    Return
-    ------
+    Returns
+    -------
     X_split: ndarray, shape (n_splits, n_channels, n_times // n_splits)
         The signal splitted in ``n_splits``.
     """
@@ -77,8 +77,8 @@ def check_univariate_signal(X):
     X : ndarray, shape (n_times,) or (n_trials, n_times)
         Signal to be reshaped. It should be a single signal.
 
-    Return
-    ------
+    Returns
+    -------
     X: ndarray, shape (n_trials, n_channels, n_times)
         The signal with the correct number of dimensions to be use with
         alphacsc transformers.
@@ -101,8 +101,8 @@ def check_multivariate_signal(X):
     X : ndarray, shape (n_channels, n_times) or (n_trials, n_channels, n_times)
         Signal to be reshaped. It should be a single signal.
 
-    Return
-    ------
+    Returns
+    -------
     X: ndarray, shape (n_trials, n_channels, n_times)
         The signal with the correct number of dimensions to be use with
         alphacsc transformers.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -115,7 +115,7 @@ html_theme_options = {
     "show_toc_level": 1,
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "switcher": {
-        "json_url": "/stable/_static/switcher.json",
+        "json_url": "https://alphacsc.github.io/stable/_static/switcher.json",
         "version_match": version_match,
     },
 }


### PR DESCRIPTION
After new release of pydata-sphinx-theme doc building does not work anymore.

- Fixes json URL path
- Fixes docstrings that give warning during doc building