### PR TITLE
update python versions in CI

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.8]
+        python: [3.10]
         dicodile: [false, true]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Update to move the CI to the latest python that numba supports (<3.11)