### PR TITLE
FIX gradient for FISTA solver+add positive argument to update_z_multi

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [3.8, 3.9, 3.10]
+     os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/alphacsc/__init__.py
+++ b/alphacsc/__init__.py
@@ -2,7 +2,8 @@ from .update_d import update_d_block
 from .learn_d_z import learn_d_z, objective
 from .learn_d_z_mcem import learn_d_z_weighted
 from .learn_d_z_multi import learn_d_z_multi
-from .utils import construct_X, check_random_state
+from .utils.convolution import construct_X
+from .utils.validation import check_random_state
 
 from .online_dictionary_learning import OnlineCDL
 from .convolutional_dictionary_learning import BatchCDL, GreedyCDL

--- a/alphacsc/_d_solver.py
+++ b/alphacsc/_d_solver.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .init_dict import get_init_strategy
 from .loss_and_gradient import gradient_uv, gradient_d
-from .utils import check_random_state
+from .utils.validation import check_random_state
 from .utils.convolution import numpy_convolve_uv
 from .utils.dictionary import NoWindow, UVWindower, SimpleWindower
 from .utils.optim import fista, power_iteration

--- a/alphacsc/_z_encoder.py
+++ b/alphacsc/_z_encoder.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from .utils import construct_X_multi
 from .utils.dictionary import get_D_shape
 from .update_z_multi import update_z_multi
+from .utils.convolution import construct_X_multi
 from .utils.dictionary import (
     _patch_reconstruction_error, get_uv, get_lambda_max
 )

--- a/alphacsc/datasets/hcp.py
+++ b/alphacsc/datasets/hcp.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from joblib import Memory
 from hcp.io.file_mapping.file_mapping import kind_map
 
-from ..utils import check_random_state
+from ..utils.validation import check_random_state
 
 
 HCP_DIR = "/storage/store/data/HCP900/"

--- a/alphacsc/datasets/simulate.py
+++ b/alphacsc/datasets/simulate.py
@@ -4,10 +4,7 @@ import numpy as np
 from joblib import Memory
 from scipy.signal import tukey
 
-try:
-    from ..utils import check_random_state
-except ValueError:
-    from alphacsc.utils import check_random_state
+from alphacsc.utils.validation import check_random_state
 
 
 mem = Memory(location='.', verbose=0)

--- a/alphacsc/init_dict.py
+++ b/alphacsc/init_dict.py
@@ -5,11 +5,11 @@
 #          Thomas Moreau <thomas.moreau@inria.fr>
 import numpy as np
 
-from .utils import check_random_state
 from .update_d_multi import prox_uv, prox_d
 
 from .utils.dictionary import tukey_window
 from .utils.dictionary import get_uv
+from .utils.validation import check_random_state
 
 
 def get_init_strategy(n_times_atom, shape, random_state, D_init):

--- a/alphacsc/learn_d_z.py
+++ b/alphacsc/learn_d_z.py
@@ -11,8 +11,9 @@ from scipy import linalg
 from joblib import Parallel
 
 from .init_dict import init_dictionary
-from .utils import construct_X, check_random_state, check_dimension
 from .utils.dictionary import get_lambda_max
+from .utils.convolution import construct_X
+from .utils.validation import check_random_state, check_dimension
 from .update_z import update_z
 from .update_d import update_d_block
 

--- a/alphacsc/learn_d_z_mcem.py
+++ b/alphacsc/learn_d_z_mcem.py
@@ -5,9 +5,9 @@
 
 import numpy as np
 
-from .utils import construct_X
-from .utils import check_dimension
-from .utils import check_random_state
+from .utils.convolution import construct_X
+from .utils.validation import check_dimension
+from .utils.validation import check_random_state
 
 from .learn_d_z import learn_d_z
 from .update_d import update_d_block

--- a/alphacsc/learn_d_z_multi.py
+++ b/alphacsc/learn_d_z_multi.py
@@ -10,8 +10,8 @@ import sys
 
 import numpy as np
 
-from .utils import check_dimension
-from .utils import check_random_state
+from .utils.validation import check_dimension
+from .utils.validation import check_random_state
 from .utils.convolution import sort_atoms_by_explained_variances
 from ._z_encoder import get_z_encoder_for
 from ._d_solver import get_solver_d

--- a/alphacsc/loss_and_gradient.py
+++ b/alphacsc/loss_and_gradient.py
@@ -9,7 +9,7 @@ import numpy as np
 from .utils.convolution import numpy_convolve_uv
 from .utils.convolution import tensordot_convolve
 from .utils.convolution import _choose_convolve_multi
-from .utils import construct_X_multi
+from .utils.convolution import construct_X_multi
 
 
 def compute_objective(X=None, X_hat=None, z_hat=None, D=None,
@@ -36,9 +36,9 @@ def compute_objective(X=None, X_hat=None, z_hat=None, D=None,
 
     if reg is not None:
         if isinstance(reg, (int, float)):
-            obj += reg * z_hat.sum()
+            obj += reg * abs(z_hat).sum()
         else:
-            obj += np.sum(reg * z_hat.sum(axis=(1, 2)))
+            obj += np.sum(reg * abs(z_hat).sum(axis=(1, 2)))
 
     return obj
 
@@ -169,9 +169,9 @@ def gradient_uv(uv, X=None, z=None, constants=None, reg=None,
     if return_func:
         if reg is not None:
             if isinstance(reg, float):
-                cost += reg * z.sum()
+                cost += reg * abs(z).sum()
             else:
-                cost += np.sum(reg * z.sum(axis=(1, 2)))
+                cost += np.sum(reg * abs(z).sum(axis=(1, 2)))
         return cost, grad
 
     return grad
@@ -189,9 +189,9 @@ def gradient_zi(Xi, zi, D=None, constants=None, reg=None,
         grad += reg
         if return_func:
             if isinstance(reg, float):
-                cost += reg * zi.sum()
+                cost += reg * abs(zi).sum()
             else:
-                cost += np.sum(reg * zi.sum(axis=1))
+                cost += np.sum(reg * abs(zi).sum(axis=1))
 
     if flatten:
         grad = grad.ravel()

--- a/alphacsc/other/motif.py
+++ b/alphacsc/other/motif.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.signal import correlate
 from scipy.linalg import eigh, blas
 
-from alphacsc.utils import check_random_state
+from alphacsc.utils.validation import check_random_state
 
 
 def learn_atoms(X, n_atoms, n_times_atom, n_iter=10, max_shift=11,

--- a/alphacsc/other/swm.py
+++ b/alphacsc/other/swm.py
@@ -12,7 +12,7 @@ neural oscillations using correlations.
 import numpy as np
 from scipy.spatial.distance import pdist
 
-from alphacsc.utils import check_random_state
+from alphacsc.utils.validation import check_random_state
 
 
 def sliding_window_matching(x, L, G, max_iterations=500, T=1,

--- a/alphacsc/simulate.py
+++ b/alphacsc/simulate.py
@@ -5,7 +5,8 @@
 
 import numpy as np
 
-from .utils import check_random_state, construct_X
+from .utils.convolution import construct_X
+from .utils.validation import check_random_state
 
 
 def simulate_data(n_trials, n_times, n_times_atom, n_atoms, random_state=42,

--- a/alphacsc/tests/conftest.py
+++ b/alphacsc/tests/conftest.py
@@ -3,7 +3,8 @@ import pytest
 import numpy as np
 
 from alphacsc.update_d_multi import prox_uv, prox_d
-from alphacsc.utils import check_random_state
+from alphacsc.utils.convolution import construct_X_multi
+from alphacsc.utils.validation import check_random_state
 from alphacsc.utils.compute_constants import compute_ztz, compute_ztX
 from alphacsc.loss_and_gradient import compute_objective
 
@@ -84,7 +85,6 @@ class MockZEncoder:
 @pytest.fixture
 def z_encoder(D_hat, rng):
 
-    from alphacsc.utils import construct_X_multi
     z_hat = rng.normal(size=(N_TRIALS, N_ATOMS, N_TIMES - N_TIMES_ATOM + 1))
 
     X = construct_X_multi(z_hat, D=D_hat, n_channels=N_CHANNELS)

--- a/alphacsc/tests/test_init_d.py
+++ b/alphacsc/tests/test_init_d.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 from alphacsc.init_dict import init_dictionary
 from alphacsc.update_d_multi import prox_uv, prox_d
 from alphacsc.learn_d_z_multi import learn_d_z_multi
-from alphacsc.utils import check_random_state
+from alphacsc.utils.validation import check_random_state
 
 from alphacsc.tests.conftest import parametrize_solver_and_constraint
 

--- a/alphacsc/tests/test_learn_d_z.py
+++ b/alphacsc/tests/test_learn_d_z.py
@@ -11,7 +11,8 @@ from alphacsc.update_d import solve_unit_norm_dual, solve_unit_norm_primal
 
 
 from alphacsc.simulate import simulate_data
-from alphacsc.utils import construct_X, check_random_state
+from alphacsc.utils.convolution import construct_X
+from alphacsc.utils.validation import check_random_state
 
 n_trials = 10
 reg = 0.1  # lambda

--- a/alphacsc/tests/test_learn_d_z_multi.py
+++ b/alphacsc/tests/test_learn_d_z_multi.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 
-from alphacsc.utils import check_random_state
+from alphacsc.utils.validation import check_random_state
 from alphacsc.learn_d_z_multi import learn_d_z_multi
 from alphacsc.convolutional_dictionary_learning import BatchCDL, GreedyCDL
 from alphacsc.online_dictionary_learning import OnlineCDL
@@ -9,7 +9,7 @@ from alphacsc.init_dict import init_dictionary
 
 from alphacsc.tests.conftest import parametrize_solver_and_constraint
 
-from conftest import N_ATOMS, N_TIMES, N_TIMES_ATOM, N_CHANNELS
+from .conftest import N_ATOMS, N_TIMES, N_TIMES_ATOM, N_CHANNELS
 
 
 @pytest.mark.parametrize('window', [False, True])

--- a/alphacsc/tests/test_loss_and_gradient.py
+++ b/alphacsc/tests/test_loss_and_gradient.py
@@ -4,8 +4,8 @@ from functools import partial
 from scipy.optimize import approx_fprime
 
 
-from alphacsc.utils import get_D
-from alphacsc.utils import construct_X_multi
+from alphacsc.utils.dictionary import get_D
+from alphacsc.utils.convolution import construct_X_multi
 from alphacsc.loss_and_gradient import gradient_d
 from alphacsc.loss_and_gradient import gradient_zi
 from alphacsc.loss_and_gradient import compute_X_and_objective_multi

--- a/alphacsc/tests/test_update_d_multi.py
+++ b/alphacsc/tests/test_update_d_multi.py
@@ -4,7 +4,7 @@ from scipy import optimize, signal
 from alphacsc.loss_and_gradient import compute_objective
 from alphacsc.loss_and_gradient import gradient_d, gradient_uv
 from alphacsc.update_d_multi import _get_d_update_constants
-from alphacsc.utils import construct_X_multi
+from alphacsc.utils.convolution import construct_X_multi
 
 
 DEBUG = True

--- a/alphacsc/tests/test_update_z_multi.py
+++ b/alphacsc/tests/test_update_z_multi.py
@@ -41,7 +41,6 @@ def test_support_least_square(solver_z):
     n_times_atom, n_atoms = 10, 4
     n_times_valid = n_times - n_times_atom + 1
     reg = 0.1
-    solver_kwargs = {'factr': 1e7} if solver_z == 'l-bfgs' else {}
 
     rng = np.random.RandomState(0)
     X = rng.randn(n_trials, n_channels, n_times)
@@ -53,15 +52,13 @@ def test_support_least_square(solver_z):
                                            feasible_evaluation=False)
 
     # The loss after updating z should be lower
-    z_hat, _, _ = update_z_multi(X, uv, reg, z0=z, solver=solver_z,
-                                 solver_kwargs=solver_kwargs)
+    z_hat, _, _ = update_z_multi(X, uv, reg, z0=z, solver=solver_z)
     loss_1 = compute_X_and_objective_multi(X, z_hat=z_hat, D_hat=uv, reg=0,
                                            feasible_evaluation=False)
     assert loss_1 < loss_0
 
     # Here we recompute z on the support of z_hat, with reg=0
     z_hat_2, _, _ = update_z_multi(X, uv, reg=0, z0=z_hat, solver=solver_z,
-                                   solver_kwargs=solver_kwargs,
                                    freeze_support=True)
     loss_2 = compute_X_and_objective_multi(X, z_hat_2, uv, 0,
                                            feasible_evaluation=False)
@@ -70,7 +67,6 @@ def test_support_least_square(solver_z):
     # Here we recompute z with reg=0, but with no support restriction
     z_hat_3, _, _ = update_z_multi(X, uv, reg=0, z0=z_hat_2,
                                    solver=solver_z,
-                                   solver_kwargs=solver_kwargs,
                                    freeze_support=True)
     loss_3 = compute_X_and_objective_multi(X, z_hat_3, uv, 0,
                                            feasible_evaluation=False)

--- a/alphacsc/tests/test_update_z_multi.py
+++ b/alphacsc/tests/test_update_z_multi.py
@@ -4,7 +4,7 @@ import numpy as np
 from alphacsc.update_z_multi import update_z_multi
 from alphacsc.update_z_multi import compute_DtD, _coordinate_descent_idx
 from alphacsc.loss_and_gradient import compute_X_and_objective_multi
-from alphacsc.utils import construct_X_multi
+from alphacsc.utils.convolution import construct_X_multi
 
 from alphacsc.utils.compute_constants import compute_ztz, compute_ztX
 
@@ -41,7 +41,7 @@ def test_support_least_square(solver_z):
     n_times_atom, n_atoms = 10, 4
     n_times_valid = n_times - n_times_atom + 1
     reg = 0.1
-    solver_kwargs = {'factr': 1e7}
+    solver_kwargs = {'factr': 1e7} if solver_z == 'l-bfgs' else {}
 
     rng = np.random.RandomState(0)
     X = rng.randn(n_trials, n_channels, n_times)

--- a/alphacsc/tests/test_z_encoder.py
+++ b/alphacsc/tests/test_z_encoder.py
@@ -4,10 +4,10 @@ import pytest
 
 from alphacsc._z_encoder import get_z_encoder_for
 from alphacsc.loss_and_gradient import compute_objective
-from alphacsc.utils import construct_X_multi
+from alphacsc.utils.convolution import construct_X_multi
 from alphacsc.utils.compute_constants import compute_ztz, compute_ztX
 
-from conftest import N_ATOMS, N_TIMES_ATOM, N_CHANNELS
+from .conftest import N_ATOMS, N_TIMES_ATOM, N_CHANNELS
 
 
 @pytest.fixture

--- a/alphacsc/update_d.py
+++ b/alphacsc/update_d.py
@@ -6,7 +6,8 @@
 import numpy as np
 from scipy import linalg, optimize
 
-from .utils import construct_X, check_consistent_shape
+from .utils.convolution import construct_X
+from .utils.validation import check_consistent_shape
 
 
 def update_d(X, Z, n_times_atom, lambd0=None, ds_init=None, debug=False,

--- a/alphacsc/update_w.py
+++ b/alphacsc/update_w.py
@@ -6,7 +6,7 @@
 import numpy as np
 from scipy.stats import levy_stable
 
-from .utils import check_random_state
+from .utils.validation import check_random_state
 
 
 def estimate_phi_mh(X, Xhat, alpha, Phi, n_iter_mcmc, n_burnin_mcmc,

--- a/alphacsc/update_z.py
+++ b/alphacsc/update_z.py
@@ -11,7 +11,7 @@ from joblib import Parallel, delayed
 
 from .utils.convolution import _choose_convolve
 from .utils.optim import power_iteration
-from .utils import check_consistent_shape
+from .utils.validation import check_consistent_shape
 
 
 def update_z(X, ds, reg, z0=None, debug=False, parallel=None,

--- a/alphacsc/update_z_multi.py
+++ b/alphacsc/update_z_multi.py
@@ -174,10 +174,11 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
             callback = None
 
         # Default values
-        lbfgs_kwargs = dict(factr=1e7, max_iter=15000)
+        lbfgs_kwargs = dict(factr=1e7, max_iter=15000, verbose=0)
         lbfgs_kwargs.update(solver_kwargs)
         lbfgs_kwargs['maxiter'] = lbfgs_kwargs['max_iter']
-        del lbfgs_kwargs['max_iter']
+        lbfgs_kwargs['disp'] = lbfgs_kwargs['verbose']
+        del lbfgs_kwargs['max_iter'], lbfgs_kwargs['verbose']
         z_hat, f, d = optimize.fmin_l_bfgs_b(
             func_and_grad, x0=z0_i, fprime=None, args=(), approx_grad=False,
             bounds=bounds, callback=callback, **lbfgs_kwargs
@@ -186,7 +187,7 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
     elif solver in ("ista", "fista"):
         # Default values
         fista_kwargs = dict(
-            max_iter=100, eps=None, verbose=10, scipy_line_search=False,
+            max_iter=100, eps=None, verbose=0, scipy_line_search=False,
             momentum=(solver == "fista"), step_size=None, debug=True,
             adaptive_step_size=True,
         )

--- a/alphacsc/update_z_multi.py
+++ b/alphacsc/update_z_multi.py
@@ -11,15 +11,16 @@ from joblib import Parallel, delayed
 
 
 from .utils.optim import fista
-from .utils import check_random_state
 from .utils.dictionary import get_D_shape
 from .loss_and_gradient import gradient_zi
+from .loss_and_gradient import compute_X_and_objective_multi
+from .utils.validation import check_random_state
 from .utils.coordinate_descent import _coordinate_descent_idx
 from .utils.compute_constants import compute_DtD, compute_ztz, compute_ztX
 
 
 def update_z_multi(X, D, reg, z0=None, solver='l-bfgs', solver_kwargs=dict(),
-                   freeze_support=False,
+                   freeze_support=False, positive=True,
                    return_ztz=False, timing=False, n_jobs=1,
                    random_state=None, debug=False):
     """Update z using L-BFGS with positivity constraints
@@ -42,6 +43,8 @@ def update_z_multi(X, D, reg, z0=None, solver='l-bfgs', solver_kwargs=dict(),
         Parameters for the solver
     freeze_support : boolean
         If True, the support of z0 is frozen.
+    positive : boolean
+        If True, impose positivity constraints on z.
     return_ztz : boolean
         If True, returns the constants ztz and ztX, used to compute D-updates.
     timing : boolean
@@ -76,10 +79,12 @@ def update_z_multi(X, D, reg, z0=None, solver='l-bfgs', solver_kwargs=dict(),
     delayed_update_z = delayed(_update_z_multi_idx)
 
     results = Parallel(n_jobs=n_jobs)(
-        delayed_update_z(X[i], D, reg, z0[i], debug, solver, solver_kwargs,
-                         freeze_support, return_ztz=return_ztz,
-                         timing=timing, random_state=seed)
-        for i, seed in enumerate(parallel_seeds))
+        delayed_update_z(
+            X[i], D, reg, z0[i], debug, solver, solver_kwargs, freeze_support,
+            positive=positive, return_ztz=return_ztz, timing=timing,
+            random_state=seed,
+        ) for i, seed in enumerate(parallel_seeds)
+    )
 
     # Post process the results to get separate objects
     z_hats, pobj, times = [], [], []
@@ -120,7 +125,8 @@ class BoundGenerator(object):
 
 def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
                         solver_kwargs=dict(), freeze_support=False,
-                        return_ztz=False, timing=False, random_state=None):
+                        positive=True, return_ztz=False, timing=False,
+                        random_state=None):
     t_start = time.time()
     n_channels, n_times = X_i.shape
     n_atoms, n_channels, n_times_atom = get_D_shape(D, n_channels)
@@ -135,26 +141,30 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
         constants['DtD'] = compute_DtD(D=D, n_channels=n_channels)
     init_timing = time.time() - t_start
 
-    def func_and_grad(zi):
-        return gradient_zi(Xi=X_i, zi=zi, D=D, constants=constants,
-                           reg=reg, return_func=True, flatten=True)
-
     if z0_i is None:
         z0_i = np.zeros(n_atoms, n_times_valid)
 
+    # Makes sure they are defined even if timing=False
     times, pobj = None, None
-    if timing:
-        times = [init_timing]
-        pobj = [func_and_grad(z0_i)[0]]
-        t_start = [time.time()]
 
     if solver == 'l-bfgs':
+
+        assert positive, "l-BFGS-B can only be used with positive=True"
+
+        def func_and_grad(zi):
+            return gradient_zi(Xi=X_i, zi=zi, D=D, constants=constants,
+                               reg=reg, return_func=True, flatten=True)
+
         z0_i = z0_i.ravel()
         if freeze_support:
             bounds = [(0, 0) if z == 0 else (0, None) for z in z0_i]
         else:
             bounds = BoundGenerator(n_atoms * n_times_valid)
         if timing:
+            times = [init_timing]
+            pobj = [func_and_grad(z0_i)[0]]
+            t_start = [time.time()]
+
             def callback(xk):
                 times.append(time.time() - t_start[0])
                 pobj.append(func_and_grad(xk)[0])
@@ -162,32 +172,51 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
                 t_start[0] = time.time()
         else:
             callback = None
-        factr = solver_kwargs.get('factr', 1e15)  # default value
-        maxiter = solver_kwargs.get('maxiter', 15000)  # default value
+
+        # Default values
+        lbfgs_kwargs = dict(factr=1e7, max_iter=15000)
+        lbfgs_kwargs.update(solver_kwargs)
+        lbfgs_kwargs['maxiter'] = lbfgs_kwargs['max_iter']
+        del lbfgs_kwargs['max_iter']
         z_hat, f, d = optimize.fmin_l_bfgs_b(
             func_and_grad, x0=z0_i, fprime=None, args=(), approx_grad=False,
-            bounds=bounds, factr=factr, maxiter=maxiter, callback=callback)
+            bounds=bounds, callback=callback, **lbfgs_kwargs
+        )
 
     elif solver in ("ista", "fista"):
-        # Default args
+        # Default values
         fista_kwargs = dict(
-            max_iter=100, eps=None, verbose=0, scipy_line_search=False,
-            momentum=(solver == "fista")
+            max_iter=100, eps=None, verbose=10, scipy_line_search=False,
+            momentum=(solver == "fista"), step_size=None, debug=True,
+            adaptive_step_size=True,
         )
         fista_kwargs.update(solver_kwargs)
 
-        def objective(z_hat):
-            return func_and_grad(z_hat)[0]
+        def objective(zi):
+            zi = zi.reshape(1, n_atoms, -1)
+            return compute_X_and_objective_multi(
+                X=X_i[None], z_hat=zi, D_hat=D, reg=reg,
+                feasible_evaluation=False
+            )
 
-        def grad(z_hat):
-            return func_and_grad(z_hat)[1]
+        def grad(zi):
+            return gradient_zi(
+                Xi=X_i, zi=zi, D=D, constants=constants, flatten=True
+            )
 
-        def prox(z_hat, step_size=0):
-            return np.maximum(z_hat - step_size * reg, 0.)
+        if positive:
+            def prox(z_hat, step_size=0):
+                return np.maximum(z_hat - step_size * reg, 0.)
+        else:
+            def prox(z_hat, step_size=0):
+                mu = reg * step_size
+                return z_hat - np.clip(z_hat, -mu, mu)
+
         z0_i = z0_i.ravel()
-        output = fista(objective, grad, prox, step_size=None, x0=z0_i,
-                       adaptive_step_size=True, timing=timing,
-                       name="Update z", **fista_kwargs)
+        output = fista(
+            objective, grad, prox, x0=z0_i, timing=timing,
+            name="Update z", **fista_kwargs
+        )
         if timing:
             z_hat, pobj, times = output
             times[0] += init_timing
@@ -197,14 +226,15 @@ def _update_z_multi_idx(X_i, D, reg, z0_i, debug, solver='l-bfgs',
     elif solver in ["lgcd", "dicodile"]:
 
         # Default values
-        tol = solver_kwargs.get('tol', 1e-3)
-        n_seg = solver_kwargs.get('n_seg', 'auto')
-        max_iter = solver_kwargs.get('max_iter', 1e15)
-        strategy = solver_kwargs.get('strategy', 'greedy')
+        lgcd_kwargs = dict(
+            tol=1e-3, n_seg='auto', max_iter=1e15, strategy="greedy"
+        )
+        lgcd_kwargs.update(solver_kwargs)
         output = _coordinate_descent_idx(
-            X_i, D, constants, reg=reg, z0=z0_i, max_iter=max_iter, tol=tol,
-            strategy=strategy, n_seg=n_seg, freeze_support=freeze_support,
-            timing=timing, random_state=rng, name="Update z")
+            X_i, D, constants, reg=reg, z0=z0_i, freeze_support=freeze_support,
+            positive=positive, timing=timing, random_state=rng,
+            name="Update z", **lgcd_kwargs
+        )
 
         if timing:
             z_hat, pobj, times = output

--- a/alphacsc/utils/__init__.py
+++ b/alphacsc/utils/__init__.py
@@ -1,9 +1,0 @@
-# flake8: noqa F401
-from .dictionary import get_D, get_uv
-from .convolution import construct_X, construct_X_multi, _choose_convolve
-from .validation import check_random_state, check_consistent_shape
-from .validation import check_dimension
-from .profile_this import profile_this
-from .signal import split_signal
-from .signal import check_univariate_signal
-from .signal import check_multivariate_signal

--- a/alphacsc/utils/tests/test_constants.py
+++ b/alphacsc/utils/tests/test_constants.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 
-from alphacsc.utils import check_random_state, get_D
+from alphacsc.utils.dictionary import get_D
+from alphacsc.utils.validation import check_random_state
 from alphacsc.utils.compute_constants import compute_DtD, compute_ztz
 from alphacsc.utils.convolution import tensordot_convolve, construct_X_multi
 

--- a/alphacsc/utils/tests/test_utils.py
+++ b/alphacsc/utils/tests/test_utils.py
@@ -4,8 +4,8 @@ from numpy.testing import assert_allclose
 
 from alphacsc.utils.convolution import _sparse_convolve, _dense_convolve
 from alphacsc.utils.convolution import _choose_convolve
-from alphacsc.utils import check_random_state
-from alphacsc.utils import construct_X_multi
+from alphacsc.utils.convolution import construct_X_multi
+from alphacsc.utils.validation import check_random_state
 from alphacsc.utils.dictionary import get_D, get_uv, flip_uv
 
 from alphacsc.update_d_multi import prox_uv

--- a/alphacsc/utils/tests/test_validation.py
+++ b/alphacsc/utils/tests/test_validation.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from alphacsc.utils import check_dimension
+from alphacsc.utils.validation import check_dimension
 
 
 def test_check_dimension():

--- a/benchmarks/1D_vs_multi_run.py
+++ b/benchmarks/1D_vs_multi_run.py
@@ -14,9 +14,9 @@ from joblib import Parallel, delayed, Memory
 
 from alphacsc.simulate import get_atoms
 from alphacsc.update_d_multi import prox_uv
-from alphacsc.utils import construct_X_multi
 from alphacsc.learn_d_z_multi import learn_d_z_multi
 from alphacsc.utils.dictionary import get_lambda_max
+from alphacsc.utils.convolution import construct_X_multi
 
 
 VERBOSE = 0

--- a/benchmarks/bench_methods_run.py
+++ b/benchmarks/bench_methods_run.py
@@ -66,7 +66,7 @@ def run_fista(X, solver_z, reg, n_iter, random_state, label):
 
     solver_z_kwargs = dict(max_iter=2)
 
-    return run_univariete(X, solver_z, solver_z_kwargs, reg, n_iter,
+    return run_univariate(X, solver_z, solver_z_kwargs, reg, n_iter,
                           random_state, label)
 
 
@@ -78,11 +78,11 @@ def run_l_bfgs(X, solver_z, reg, n_iter, random_state, label):
     solver_z_kwargs = dict(factr=factr_z)
     solver_d_kwargs = dict(factr=factr_d)
 
-    return run_univariete(X, solver_z, solver_z_kwargs, reg, n_iter,
+    return run_univariate(X, solver_z, solver_z_kwargs, reg, n_iter,
                           random_state, label, solver_d_kwargs)
 
 
-def run_univariete(X, solver_z, solver_z_kwargs, reg, n_iter, random_state,
+def run_univariate(X, solver_z, solver_z_kwargs, reg, n_iter, random_state,
                    label, solver_d_kwargs=dict()):
     assert X.ndim == 2
 

--- a/benchmarks/scaling_channels_run.py
+++ b/benchmarks/scaling_channels_run.py
@@ -17,10 +17,11 @@ import pandas as pd
 import scipy.sparse as sp
 from joblib import Parallel, delayed, Memory
 
-from alphacsc.utils.profile_this import profile_this  # noqa
-from alphacsc.utils import check_random_state, get_D
 from alphacsc.learn_d_z_multi import learn_d_z_multi
+from alphacsc.utils.dictionary import get_D
 from alphacsc.utils.dictionary import get_lambda_max
+from alphacsc.utils.validation import check_random_state
+from alphacsc.utils.profile_this import profile_this  # noqa
 
 
 START = time.time()
@@ -48,7 +49,8 @@ def run_multichannel(X, D_init, reg, n_iter, random_state,
     solver_z_kwargs = dict(max_iter=500, tol=1e-1)
     return learn_d_z_multi(
         X, n_atoms, n_times_atom, reg=reg, n_iter=n_iter,
-        uv_constraint='separate', rank1=True, D_init=D_init,
+        uv_constraint='s
+        eparate', rank1=True, D_init=D_init,
         solver_d='alternate_adaptive', solver_d_kwargs=dict(max_iter=50),
         solver_z="lgcd", solver_z_kwargs=solver_z_kwargs,
         name="rank1-{}-{}".format(n_channels, random_state),

--- a/examples/dicodile/plot_gait.py
+++ b/examples/dicodile/plot_gait.py
@@ -124,7 +124,7 @@ fig = display_dictionaries(D_init, D_hat)
 ###############################################################################
 # Now, let's reconstruct the original signal.
 
-from alphacsc.utils import construct_X_multi
+from alphacsc.utils.convolution import construct_X_multi
 
 z_hat = res._z_hat
 
@@ -229,7 +229,7 @@ res = cdl.fit(X_mc_subset)
 ###############################################################################
 # Now, let’s reconstruct the original signal
 
-from alphacsc.utils import construct_X_multi
+from alphacsc.utils.convolution import construct_X_multi
 
 z_hat_mc = res._z_hat
 

--- a/examples/multicsc/plot_sample_evoked_response.py
+++ b/examples/multicsc/plot_sample_evoked_response.py
@@ -122,7 +122,8 @@ print('done')
 # To reduce the impact of border artifacts, we use `apply_window=True`
 # which scales down the border of each split with a tukey window.
 
-from alphacsc.utils import split_signal
+from alphacsc.utils.signal import split_signal
+
 X = raw.get_data(picks=['meg'])
 info = raw.copy().pick_types(meg=True).info  # info of the loaded channels
 X_split = split_signal(X, n_splits=n_splits, apply_window=True)


### PR DESCRIPTION
- The gradient for the FISTA solver was wrong, it relied on the subgradient used in `l-BFGS`. We could either change the prox to a projection or change the gradient to only include the `l2` loss. I choose the later for consistency with `positive=False`.
- Added a `positive=True` argument, so we can also solve the negative case. This does not make the code more complex but it will accomodate different cases so I think it is worth adding.